### PR TITLE
Remove non-posix fgetpwent to fix FreeBSD

### DIFF
--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -40,7 +40,6 @@ nss_module_register (const char *name, unsigned int *size,      \
 
 #define OSLOGIN_PASSWD_CACHE_PATH "/usr/local/etc/oslogin_passwd.cache"
 #define OSLOGIN_GROUP_CACHE_PATH "/usr/local/etc/oslogin_group.cache"
-#define PASSWD_PATH "/usr/local/etc/passwd"
 
 #define K_DEFAULT_PFILE_PATH "/usr/local/etc/oslogin_passwd.cache"
 #define K_DEFAULT_BACKUP_PFILE_PATH "/usr/local/etc/oslogin_passwd.cache.bak"
@@ -56,7 +55,6 @@ nss_module_register (const char *name, unsigned int *size,      \
 
 #define OSLOGIN_PASSWD_CACHE_PATH "/etc/oslogin_passwd.cache"
 #define OSLOGIN_GROUP_CACHE_PATH "/etc/oslogin_group.cache"
-#define PASSWD_PATH "/etc/passwd"
 
 #define K_DEFAULT_PFILE_PATH "/etc/oslogin_passwd.cache"
 #define K_DEFAULT_BACKUP_PFILE_PATH "/etc/oslogin_passwd.cache.bak"

--- a/src/nss/nss_oslogin.cc
+++ b/src/nss/nss_oslogin.cc
@@ -221,14 +221,10 @@ enum nss_status _nss_oslogin_initgroups_dyn(const char *user, gid_t skipgroup,
                                             gid_t **groupsp, long int limit,
                                             int *errnop) {
   // check if user exists in local passwd DB
-  FILE *p_file = fopen(PASSWD_PATH, "r");
-  if (p_file == NULL)
-    return NSS_STATUS_NOTFOUND;
   struct passwd *userp;
-  while ((userp = fgetpwent(p_file)) != NULL)
+  while ((userp = getpwent()) != NULL)
     if (strcmp(userp->pw_name, user) == 0)
       return NSS_STATUS_NOTFOUND;
-  fclose(p_file);
 
   std::vector<Group> grouplist;
   if (!GetGroupsForUser(string(user), &grouplist, errnop)) {


### PR DESCRIPTION
fgetpwent is not part of POSIX and it is not available in FreeBSD.
Also, getpwent() already reads from the local database, use it instead
and remove fgetpwent()