### PR TITLE
add CLOEXEC to fopen call

### DIFF
--- a/src/nss/nss_cache_oslogin.c
+++ b/src/nss/nss_cache_oslogin.c
@@ -72,7 +72,7 @@ static inline enum nss_status _nss_cache_oslogin_ent_bad_return_code(
 
 static enum nss_status _nss_cache_oslogin_setpwent_locked(void) {
   DEBUG("%s %s\n", "Opening", OSLOGIN_PASSWD_CACHE_PATH);
-  p_file = fopen(OSLOGIN_PASSWD_CACHE_PATH, "r");
+  p_file = fopen(OSLOGIN_PASSWD_CACHE_PATH, "re");
 
   if (p_file) {
     return NSS_STATUS_SUCCESS;
@@ -209,7 +209,7 @@ enum nss_status _nss_cache_oslogin_getpwnam_r(const char *name,
 
 static enum nss_status _nss_cache_oslogin_setgrent_locked(void) {
   DEBUG("%s %s\n", "Opening", OSLOGIN_GROUP_CACHE_PATH);
-  g_file = fopen(OSLOGIN_GROUP_CACHE_PATH, "r");
+  g_file = fopen(OSLOGIN_GROUP_CACHE_PATH, "re");
 
   if (g_file) {
     return NSS_STATUS_SUCCESS;

--- a/src/nss/nss_oslogin.cc
+++ b/src/nss/nss_oslogin.cc
@@ -221,7 +221,7 @@ enum nss_status _nss_oslogin_initgroups_dyn(const char *user, gid_t skipgroup,
                                             gid_t **groupsp, long int limit,
                                             int *errnop) {
   // check if user exists in local passwd DB
-  FILE *p_file = fopen(PASSWD_PATH, "r");
+  FILE *p_file = fopen(PASSWD_PATH, "re");
   if (p_file == NULL)
     return NSS_STATUS_NOTFOUND;
 


### PR DESCRIPTION
Add the `O_CLOEXEC` flag to all `fopen()` calls. See `open (2)` for a description of this behavior change.