### PR TITLE
set passwords to !

### DIFF
--- a/src/cache_refresh/cache_refresh.cc
+++ b/src/cache_refresh/cache_refresh.cc
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <syslog.h>
+#include <string.h>
 #include <unistd.h>
 #include <sstream>
 
@@ -79,6 +80,9 @@ int refreshpasswdcache() {
         break;
       }
       continue;
+    }
+    if (strlen(pwd.pw_passwd) == 0) {
+      pwd.pw_passwd = (char *)"!";
     }
     cache_file << pwd.pw_name << ":" << pwd.pw_passwd << ":" << pwd.pw_uid
                << ":" << pwd.pw_gid << ":" << pwd.pw_gecos << ":" << pwd.pw_dir

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -49,6 +49,7 @@ nss_module_register (const char *name, unsigned int *size,      \
 
 #define PAM_SYSLOG(pamh, ...) syslog(__VA_ARGS__)
 #define DEFAULT_SHELL "/bin/sh"
+#define DEFAULT_PASSWD "!"
 
 #else /* __FreeBSD__ */
 
@@ -65,6 +66,7 @@ nss_module_register (const char *name, unsigned int *size,      \
 
 #define PAM_SYSLOG pam_syslog
 #define DEFAULT_SHELL "/bin/bash"
+#define DEFAULT_PASSWD "!"
 
 #define DECLARE_NSS_METHOD_TABLE(name, ...)
 #define NSS_METHOD_PROTOTYPE(m)

--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -373,13 +373,14 @@ bool ValidatePasswd(struct passwd* result, BufferManager* buf, int* errnop) {
       return false;
     }
   }
-
-  // OS Login does not utilize the passwd field and reserves the gecos field.
-  // Set these to be empty.
-  if (!buf->AppendString("", &result->pw_gecos, errnop)) {
-    return false;
+  if (strlen(result->pw_passwd) == 0) {
+    if (!buf->AppendString(DEFAULT_PASSWD, &result->pw_passwd, errnop)) {
+      return false;
+    }
   }
-  if (!buf->AppendString("", &result->pw_passwd, errnop)) {
+
+  // OS Login reserves the GECOS field.
+  if (!buf->AppendString("", &result->pw_gecos, errnop)) {
     return false;
   }
   return true;
@@ -572,6 +573,7 @@ bool ParseJsonToPasswd(const string& json, struct passwd* result, BufferManager*
   result->pw_shell = (char*)"";
   result->pw_name = (char*)"";
   result->pw_dir = (char*)"";
+  result->pw_passwd = (char*)"";
 
   // Iterate through the json response and populate the passwd struct.
   if (json_object_get_type(posix_accounts) != json_type_object) {


### PR DESCRIPTION
Set passwords by default to "!". This is the default "locked" password. it is not a valid password, and it also is not "x" which has the special meaning of "consult the shadow file". 
This is to prevent passwordless `su` usage of OS Login accounts, except by root.