### PR TITLE
Update logic in the cache_refresh binary

### DIFF
--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -205,7 +205,7 @@ bool NssCache::LoadJsonGroupsToCache(string response) {
 //
 // * EINVAL  - current user entry was malformed in some way.
 // * ERANGE  - the page of results did not fit into the provided buffer.
-// * ENOMSG  - a 404 error when contacting the metadata server, indicating that
+// * ENOMSG  - a 404 error was received when contacting the metadata server, indicating that
 //             OS Login is not enabled in the instance metadata.
 // * ENOENT  - a general failure to load the cache occurred. Behavior of retries
 //             following ENOENT is undefined.
@@ -240,7 +240,7 @@ bool NssCache::NssGetpwentHelper(BufferManager* buf, struct passwd* result, int*
 //
 // * EINVAL  - current group entry was malformed in some way.
 // * ERANGE  - the page of results did not fit into the provided buffer.
-// * ENOMSG  - a 404 error when contacting the metadata server, indicating that
+// * ENOMSG  - a 404 error was received when contacting the metadata server, indicating that
 //             OS Login is not enabled in the instance metadata.
 // * ENOENT  - a general failure to load the cache occurred. Behavior of retries
 //             following ENOENT is undefined.


### PR DESCRIPTION
This commit updates the logic in the cache_refresh binary with the
following behaviors, for both users and groups:
  - If the metadata server returns successfully, but returns no users,
    create an empty cache file.
  - If the metadata server returns a 404 error, this means that OS Login
    is not enabled. Create a special error code for this and do not log an
    error if we see this code.
  - If the metadata server returns an error, don't update the cache file
    and log and error. If no cache file exists, add an empty one.