### PR TITLE
clear users vector

### DIFF
--- a/src/cache_refresh/cache_refresh.cc
+++ b/src/cache_refresh/cache_refresh.cc
@@ -148,6 +148,7 @@ int refreshgroupcache() {
       continue;
     }
     std::string name(grp.gr_name);
+    users.clear();
     if (!GetUsersForGroup(name, &users, &error_code)) {
       syslog(LOG_ERR,
              "Error getting users for group %s (error_code %d), skipping.",


### PR DESCRIPTION
fixes a bug where users vector grows continuously, producing incorrect group memberships