### PR TITLE
support empty groups

### DIFF
--- a/src/cache_refresh/cache_refresh.cc
+++ b/src/cache_refresh/cache_refresh.cc
@@ -155,10 +155,12 @@ int refreshgroupcache() {
              grp.gr_name, error_code);
       continue;
     }
-    cache_file << grp.gr_name << ":" << grp.gr_passwd << ":" << grp.gr_gid << ":" << users.front();
-    users.erase(users.begin());
+    cache_file << grp.gr_name << ":" << grp.gr_passwd << ":" << grp.gr_gid << ":";
     for (int i = 0; i < (int)users.size(); i++) {
-      cache_file << "," << users[i];
+      if (i > 0) {
+        cache_file << ",";
+      }
+      cache_file << users[i];
     }
     cache_file << "\n";
   }

--- a/src/nss/nss_oslogin.cc
+++ b/src/nss/nss_oslogin.cc
@@ -194,7 +194,7 @@ enum nss_status _nss_oslogin_getgrgid_r(gid_t gid, struct group *grp, char *buf,
   if (!GetUsersForGroup(grp->gr_name, &users, errnop))
     return *errnop == ERANGE ? NSS_STATUS_TRYAGAIN : NSS_STATUS_NOTFOUND;
 
-  if (!AddUsersToGroup(users, grp, &buffer_manager, errnop))
+  if (!users.empty() && !AddUsersToGroup(users, grp, &buffer_manager, errnop))
     return *errnop == ERANGE ? NSS_STATUS_TRYAGAIN : NSS_STATUS_NOTFOUND;
 
   return NSS_STATUS_SUCCESS;
@@ -223,7 +223,7 @@ enum nss_status _nss_oslogin_getgrnam_r(const char *name, struct group *grp,
   if (!GetUsersForGroup(grp->gr_name, &users, errnop))
     return *errnop == ERANGE ? NSS_STATUS_TRYAGAIN : NSS_STATUS_NOTFOUND;
 
-  if (!AddUsersToGroup(users, grp, &buffer_manager, errnop))
+  if (!users.empty() && !AddUsersToGroup(users, grp, &buffer_manager, errnop))
     return *errnop == ERANGE ? NSS_STATUS_TRYAGAIN : NSS_STATUS_NOTFOUND;
 
   return NSS_STATUS_SUCCESS;

--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -414,7 +414,7 @@ bool ParseJsonToUsers(const string& json, std::vector<string>* result) {
 
   json_object* users = NULL;
   if (!json_object_object_get_ex(root, "usernames", &users)) {
-    return false;
+    return true;
   }
   if (json_object_get_type(users) != json_type_array) {
     return false;
@@ -925,7 +925,6 @@ bool GetUsersForGroup(string groupname, std::vector<string>* users, int* errnop)
       pageToken = "";
     }
     if (!ParseJsonToUsers(response, users)) {
-    // TODO: what if there are no users? add a test.
       *errnop = EINVAL;
       return false;
     }

--- a/test/oslogin_utils_test.cc
+++ b/test/oslogin_utils_test.cc
@@ -406,21 +406,11 @@ TEST(ParseJsonToUsersTest, ParseJsonToUsersSucceeds) {
 
 // Test parsing a valid JSON response from the metadata server.
 TEST(ParseJsonToUsersTest, ParseJsonToUsersEmptyGroupSucceeds) {
-  string test_group_users = "{\"usernames\":[]}";
+  string test_group_users = "{\"nextPageToken\":\"0\"}";
 
   std::vector<string> users;
   ASSERT_TRUE(ParseJsonToUsers(test_group_users, &users));
   ASSERT_TRUE(users.empty());
-}
-
-// Test parsing malformed JSON responses.
-TEST(ParseJsonToUsersTest, ParseJsonToUsersFails) {
-  string test_group_users =
-      "{\"badstuff\":[\"user0001\",\"user0002\",\"user0003\",\"user0004\","
-      "\"user0005\"]}";
-
-  std::vector<string> users;
-  ASSERT_FALSE(ParseJsonToUsers(test_group_users, &users));
 }
 
 TEST(GetUsersForGroupTest, GetUsersForGroupSucceeds) {


### PR DESCRIPTION
* modify `ParseJsonToUsers` to not return error if the 'usernames' attribute is missing, as this is the normal behavior for an empty group.
* modify callers not to assume users vector has members