### PR TITLE
flush each group member write

### DIFF
--- a/src/cache_refresh/cache_refresh.cc
+++ b/src/cache_refresh/cache_refresh.cc
@@ -62,6 +62,7 @@ int refreshpasswdcache() {
     syslog(LOG_ERR, "Failed to open file %s.", kDefaultBackupFilePath);
     return -1;
   }
+  cache_file << std::unitbuf; // enable automatic flushing
   chown(kDefaultBackupFilePath, 0, 0);
   chmod(kDefaultBackupFilePath, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 
@@ -125,6 +126,7 @@ int refreshgroupcache() {
     syslog(LOG_ERR, "Failed to open file %s.", kDefaultBackupGroupPath);
     return -1;
   }
+  cache_file << std::unitbuf; // enable automatic flushing
   chown(kDefaultBackupGroupPath, 0, 0);
   chmod(kDefaultBackupGroupPath, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 


### PR DESCRIPTION
add std::unitbuf[1] to cause each write to be immediately flushed. 

[1]: https://en.cppreference.com/w/cpp/io/manip/unitbuf