### PR TITLE
add authorized_keys_sk

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ NSS_CACHE_OSLOGIN        = libnss_cache_oslogin-$(VERSION).so
 PAM_LOGIN                = pam_oslogin_login.so
 PAM_ADMIN                = pam_oslogin_admin.so
 
-BINARIES = google_oslogin_nss_cache google_authorized_keys
+BINARIES = google_oslogin_nss_cache google_authorized_keys google_authorized_keys_sk
 
 all : $(NSS_OSLOGIN) $(NSS_CACHE_OSLOGIN) $(PAM_LOGIN) $(PAM_ADMIN) $(BINARIES)
 
@@ -61,6 +61,9 @@ $(PAM_ADMIN) : pam/pam_oslogin_admin.o oslogin_utils.o
 # Utilities.
 
 google_authorized_keys : authorized_keys/authorized_keys.o oslogin_utils.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
+
+google_authorized_keys_sk : authorized_keys/authorized_keys_sk.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
 google_oslogin_nss_cache: cache_refresh/cache_refresh.o oslogin_utils.o

--- a/src/authorized_keys/authorized_keys_sk.cc
+++ b/src/authorized_keys/authorized_keys_sk.cc
@@ -1,0 +1,78 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <oslogin_utils.h>
+
+using std::cout;
+using std::endl;
+using std::string;
+
+using oslogin_utils::HttpGet;
+using oslogin_utils::ParseJsonToSuccess;
+using oslogin_utils::ParseJsonToEmail;
+using oslogin_utils::ParseJsonToSshKeysSk;
+using oslogin_utils::UrlEncode;
+using oslogin_utils::kMetadataServerUrl;
+
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    cout << "usage: authorized_keys_sk [username]" << endl;
+    return 1;
+  }
+  std::stringstream url;
+  url << kMetadataServerUrl << "users?username=" << UrlEncode(argv[1])
+      << "&view=securityKey";
+  string user_response;
+  long http_code = 0;
+  if (!HttpGet(url.str(), &user_response, &http_code) ||
+      user_response.empty() || http_code != 200) {
+    if (http_code == 404) {
+      // Return 0 if the user is not an oslogin user. If we returned a failure
+      // code, we would populate auth.log with useless error messages.
+      return 0;
+    }
+    return 1;
+  }
+  string email;
+  if (!ParseJsonToEmail(user_response, &email) || email.empty()) {
+    return 1;
+  }
+  // Redundantly verify that this user has permission to log in to this VM.
+  // Normally the PAM module determines this, but in the off chance a transient
+  // error causes the PAM module to permit a user without login permissions,
+  // perform the same check here. If this fails, we can guarantee that we won't
+  // accidentally allow a user to log in without permissions.
+  url.str("");
+  url << kMetadataServerUrl << "authorize?email=" << UrlEncode(email)
+      << "&policy=login";
+  string auth_response;
+  if (!HttpGet(url.str(), &auth_response, &http_code) || http_code != 200 ||
+      auth_response.empty()) {
+    return 1;
+  }
+  if (!ParseJsonToSuccess(auth_response)) {
+    return 1;
+  }
+  // At this point, we've verified the user can log in. Grab the ssh keys from
+  // the user response.
+  std::vector<string> ssh_keys = ParseJsonToSshKeysSk(user_response);
+  for (size_t i = 0; i < ssh_keys.size(); i++) {
+    cout << ssh_keys[i] << endl;
+  }
+  return 0;
+}

--- a/src/include/oslogin_utils.h
+++ b/src/include/oslogin_utils.h
@@ -247,6 +247,7 @@ bool ParseJsonToUsers(const string& json, std::vector<string> *users);
 // ssh_keys. A key is considered valid if it's expiration date is greater than
 // current unix time.
 std::vector<string> ParseJsonToSshKeys(const string& json);
+std::vector<string> ParseJsonToSshKeysSk(const string& json);
 
 // Parses a JSON object and returns the value associated with a given key.
 bool ParseJsonToKey(const string& json, const string& key, string* response);


### PR DESCRIPTION
add a new binary `google_authorized_keys_sk` which acts the same as `google_authorized_keys`, but only for security keys.