### PR TITLE
include cstdlib for exit

### DIFF
--- a/src/authorized_keys/authorized_keys.cc
+++ b/src/authorized_keys/authorized_keys.cc
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <cstdlib>
 
 #include <signal.h>
 


### PR DESCRIPTION
contains definition for exit()