### PR TITLE
use sigaction for signals

### DIFF
--- a/src/authorized_keys/authorized_keys.cc
+++ b/src/authorized_keys/authorized_keys.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <cstdlib>
 
 #include <signal.h>
 
@@ -42,10 +42,16 @@ int main(int argc, char* argv[]) {
     cout << "usage: authorized_keys [username]" << endl;
     return 1;
   }
-  if (signal(SIGPIPE, sigpipe_handler) == SIG_ERR) {
+
+  struct sigaction newact;
+  newact.sa_handler = sigpipe_handler;
+  sigemptyset(&newact.sa_mask);
+  newact.sa_flags = 0;
+  if (sigaction(SIGPIPE, &newact, NULL) == -1) {
     cout << "Unable to add SIGPIPE handler, exiting" << endl;
     return 1;
   }
+
   std::stringstream url;
   url << kMetadataServerUrl << "users?username=" << UrlEncode(argv[1]);
   string user_response;

--- a/src/authorized_keys/authorized_keys.cc
+++ b/src/authorized_keys/authorized_keys.cc
@@ -34,7 +34,7 @@ using oslogin_utils::kMetadataServerUrl;
 
 void sigpipe_handler(int signo) {
   // exit 0 so SSHD can use what we've already written out.
-  exit(0);
+  _Exit(0);
 }
 
 int main(int argc, char* argv[]) {

--- a/src/authorized_keys/authorized_keys_sk.cc
+++ b/src/authorized_keys/authorized_keys_sk.cc
@@ -36,7 +36,7 @@ using oslogin_utils::kMetadataServerUrl;
 
 void sigpipe_handler(int signo) {
   // exit 0 so SSHD can use what we've already written out.
-  exit(0);
+  _Exit(0);
 }
 
 int main(int argc, char* argv[]) {

--- a/src/authorized_keys/authorized_keys_sk.cc
+++ b/src/authorized_keys/authorized_keys_sk.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
+
+#include <signal.h>
 #include <string.h>
 
 #include <oslogin_utils.h>
@@ -31,9 +34,23 @@ using oslogin_utils::ParseJsonToSshKeysSk;
 using oslogin_utils::UrlEncode;
 using oslogin_utils::kMetadataServerUrl;
 
+void sigpipe_handler(int signo) {
+  // exit 0 so SSHD can use what we've already written out.
+  exit(0);
+}
+
 int main(int argc, char* argv[]) {
   if (argc != 2) {
     cout << "usage: authorized_keys_sk [username]" << endl;
+    return 1;
+  }
+
+  struct sigaction newact;
+  newact.sa_handler = sigpipe_handler;
+  sigemptyset(&newact.sa_mask);
+  newact.sa_flags = 0;
+  if (sigaction(SIGPIPE, &newact, NULL) == -1) {
+    cout << "Unable to add SIGPIPE handler, exiting" << endl;
     return 1;
   }
 


### PR DESCRIPTION
* Add signal handler to google_authorized_keys_sk.
* replace exit(3) with _Exit(2) as it is a signal-handler safe function.
* Replace signal(2) with sigaction(2) for portability and to avoid setting feature test macros, per documentation:

> "The semantics when using **signal**() to establish a signal handler vary across systems (and POSIX.1 explicitly permits this variation); **do not use it for this purpose**."

(emphasis in original)