### PR TITLE
don't log error when no groups exist

### DIFF
--- a/src/include/oslogin_utils.h
+++ b/src/include/oslogin_utils.h
@@ -121,7 +121,7 @@ class NssCache {
   // response is expected to be a JSON array of passwd or group entries. Returns
   // true on success.
   bool LoadJsonUsersToCache(string response);
-  bool LoadJsonGroupsToCache(string response);
+  bool LoadJsonGroupsToCache(string response, int* errnop);
 
   // Helper method for get(pw|gr)ent nss methods. Each call will iterate through the
   // OsLogin database and return the next entry.  Internally, the cache will


### PR DESCRIPTION
The cache_refresh binary is already written to treat ENOMSG to mean OS Login is functioning but there are no groups in the response, and logs differently in this case. This PR just plumbs errno through to the relevant JSON parsing function so we can disambiguate between no groups in response and invalid response/failure to parse response.