### PR TITLE
Cleanup Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,42 @@
-all install :
+.PHONY: all clean install
+.PHONY: prowbuild prowtest
+.PHONY: alltests non_network_tests network_tests
+
+.DEFAULT_GOAL := all
+
+all install:
 	$(MAKE) -C src $@
 
-alltests non_network_tests network_tests :
+alltests non_network_tests network_tests:
 	$(MAKE) -C test $@
 
-clean :
+clean:
 	$(MAKE) -C src clean
 	$(MAKE) -C test clean
+	rm -f debian_deps debian_build_deps debian_test_deps
+	rm -f rhel_deps rhel_build_deps
 
-prowbuild : debian_deps all
+prowbuild: debian_build_deps all
 
-prowtest : debian_deps non_network_tests
-	mv test/test_detail.xml ${ARTIFACTS}/junit.xml
+prowtest: debian_deps non_network_tests
+	mv -f test/test_detail.xml ${ARTIFACTS}/junit.xml
 
-debian_deps :
+debian_deps: debian_build_deps debian_test_deps
+	touch $@
+
+debian_build_deps:
 	apt-get -y install g++ libcurl4-openssl-dev libjson-c-dev libpam-dev \
-		googletest && touch $@
+	&& touch $@
 
-.PHONY : all clean install prowbuild prowtest alltests non_network_tests network_tests
+debian_test_deps:
+	apt-get -y install googletest \
+	&& touch $@
+
+rhel_deps: rhel_build_deps
+	touch $@
+
+rhel_build_deps:
+	dnf config-manager --set-enabled crb \
+	&& dnf install -y policycoreutils gcc-c++ boost-devel libcurl-devel \
+					json-c-devel pam-devel policycoreutils \
+	&& touch $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,38 +32,39 @@ PAM_ADMIN                = pam_oslogin_admin.so
 
 BINARIES = google_oslogin_nss_cache google_authorized_keys google_authorized_keys_sk
 
-all : $(NSS_OSLOGIN) $(NSS_CACHE_OSLOGIN) $(PAM_LOGIN) $(PAM_ADMIN) $(BINARIES)
+.PHONY: all clean install
+.DEFAULT_GOAL := all
 
-clean :
+all: $(NSS_OSLOGIN) $(NSS_CACHE_OSLOGIN) $(PAM_LOGIN) $(PAM_ADMIN) $(BINARIES)
+
+clean:
 	rm -f $(BINARIES)
 	find . -type f \( -iname '*.o' -o -iname '*.so' \) -delete
 
-.PHONY : all clean install
-
 # NSS modules.
 
-$(NSS_OSLOGIN) : SONAME = $(NSS_OSLOGIN_SONAME)
-$(NSS_OSLOGIN) : nss/nss_oslogin.o oslogin_utils.o
+$(NSS_OSLOGIN): SONAME = $(NSS_OSLOGIN_SONAME)
+$(NSS_OSLOGIN): nss/nss_oslogin.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
-$(NSS_CACHE_OSLOGIN) : SONAME = $(NSS_CACHE_OSLOGIN_SONAME)
-$(NSS_CACHE_OSLOGIN) : nss/nss_cache_oslogin.o nss/compat/getpwent_r.o oslogin_utils.o
+$(NSS_CACHE_OSLOGIN): SONAME = $(NSS_CACHE_OSLOGIN_SONAME)
+$(NSS_CACHE_OSLOGIN): nss/nss_cache_oslogin.o nss/compat/getpwent_r.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 # PAM modules
 
-$(PAM_LOGIN) : pam/pam_oslogin_login.o oslogin_utils.o
+$(PAM_LOGIN): pam/pam_oslogin_login.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -shared $^ -o $@ $(PAMLIBS)
 
-$(PAM_ADMIN) : pam/pam_oslogin_admin.o oslogin_utils.o
+$(PAM_ADMIN): pam/pam_oslogin_admin.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -shared $^ -o $@ $(PAMLIBS)
 
 # Utilities.
 
-google_authorized_keys : authorized_keys/authorized_keys.o oslogin_utils.o
+google_authorized_keys: authorized_keys/authorized_keys.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
-google_authorized_keys_sk : authorized_keys/authorized_keys_sk.o oslogin_utils.o
+google_authorized_keys_sk: authorized_keys/authorized_keys_sk.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
 google_oslogin_nss_cache: cache_refresh/cache_refresh.o oslogin_utils.o
@@ -85,8 +86,8 @@ install: all
 	install -m 0755 -t $(DESTDIR)$(BINDIR) $(BINARIES)
 	# Manpages
 	install -m 0644 -t $(DESTDIR)$(MANDIR)/man8 $(TOPDIR)/man/nss-oslogin.8 $(TOPDIR)/man/nss-cache-oslogin.8
-	gzip -9 $(DESTDIR)$(MANDIR)/man8/nss-oslogin.8
-	gzip -9 $(DESTDIR)$(MANDIR)/man8/nss-cache-oslogin.8
+	gzip -9f $(DESTDIR)$(MANDIR)/man8/nss-oslogin.8
+	gzip -9f $(DESTDIR)$(MANDIR)/man8/nss-cache-oslogin.8
 	ln -sf nss-oslogin.8.gz       $(DESTDIR)$(MANDIR)/man8/$(NSS_OSLOGIN_SONAME).8.gz
 	ln -sf nss-cache-oslogin.8.gz $(DESTDIR)$(MANDIR)/man8/$(NSS_CACHE_OSLOGIN_SONAME).8.gz
 ifdef INSTALL_SELINUX

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,38 +10,40 @@ CPPFLAGS += -I$(TOPDIR)/src/include -I/usr/include/json-c -I$(GTEST_DIR) -isyste
 CXXFLAGS += -g -Wall -Wextra -std=c++11
 LDLIBS = -lcurl -ljson-c -lpthread
 
-all : test_runner new_test_runner non_network_tests
+.PHONY: all clean alltests ping reset
+.PHONY: gtest prowtest non_network_tests network_tests
+.DEFAULT_GOAL := all
+
+all: test_runner new_test_runner non_network_tests
 
 clean :
-	rm -f test_runner *.o
+	rm -f test_runner new_test_runner test_detail.xml *.o
 
-gtest-all.o : $(GTEST_DIR)/src/gtest-all.cc
+gtest-all.o: $(GTEST_DIR)/src/gtest-all.cc
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $^
 
-test_runner : oslogin_utils_test.o $(TOPDIR)/src/oslogin_utils.o gtest-all.o
+test_runner: oslogin_utils_test.o $(TOPDIR)/src/oslogin_utils.o gtest-all.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
-new_test_runner : oslogin_test.o gtest-all.o
+new_test_runner: oslogin_test.o gtest-all.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
-new_tests : new_test_runner $(TOPDIR)/src/nss/new_nss_oslogin.c
+new_tests: new_test_runner $(TOPDIR)/src/nss/new_nss_oslogin.c
 	$(NEW_TEST_RUNNER) ${GTESTARGS}
 
-non_network_tests : test_runner new_test_runner
+non_network_tests: test_runner new_test_runner
 	$(TEST_RUNNER) --gtest_filter=*-GetGroupByTest.*:GetUsersForGroupTest.*
 	$(NEW_TEST_RUNNER) --gtest_filter=ParserTest.*
 
-network_tests : test_runner ping reset
+network_tests: test_runner ping reset
 	$(TEST_RUNNER) --gtest_filter=GetGroupByTest.*:GetUsersForGroupTest.*
 
 # run as $ make tests GTESTARGS="--gtest_filter=GetGroupByTest.*"
-alltests : test_runner
+alltests: test_runner
 	$(TEST_RUNNER) ${GTESTARGS}
 
-ping :
+ping:
 	nc -vzw2 169.254.169.254 80 >/dev/null 2>&1
 
-reset :
+reset:
 	curl -Ss http://169.254.169.254/reset >/dev/null 2>&1
-
-.PHONY : all clean alltests ping reset gtest prowtest non_network_tests network_tests


### PR DESCRIPTION
- consistent formating across all files (space between a target and a semicolon)
- add targets for installing build dependencies on RHEL-like systems (this is useful for quick creation of a build/dev environment)
- the clean target now cleans a bit better
- installation of man-pages doesn't ask for confirmations on overrides
- clearly defined a default target