### PR TITLE
PAM cleanup: remove duplicates

### DIFF
--- a/src/include/oslogin_utils.h
+++ b/src/include/oslogin_utils.h
@@ -220,11 +220,6 @@ bool ParseJsonToGroups(const string& json, std::vector<Group>* groups);
 // Parses a JSON users response, storing results in a provided string vector.
 bool ParseJsonToUsers(const string& json, std::vector<string>* users);
 
-// Adds users and associated array of char* to provided buffer and store pointer
-// to array in result.gr_mem.
-bool AddUsersToGroup(std::vector<string> users, struct group* result,
-                       BufferManager* buf, int* errnop);
-
 // Gets group matching name.
 bool GetGroupByName(string name, struct group* grp, BufferManager* buf, int* errnop);
 

--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -17,7 +17,6 @@
 #include <errno.h>
 #include <grp.h>
 #include <json.h>
-#include <grp.h>
 #include <nss.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Remove duplicates in a header include and a function declaration.
