### PR TITLE
Improve the URL in 2fa prompt

### DIFF
--- a/src/pam/pam_oslogin_login.cc
+++ b/src/pam/pam_oslogin_login.cc
@@ -265,7 +265,7 @@ pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc,
     }
   } else if (challenge.type == SECURITY_KEY_OTP) {
     if (pam_prompt(pamh, PAM_PROMPT_ECHO_ON, &user_token,
-        "Enter your security code by visiting g.co/sc: ") != PAM_SUCCESS) {
+        "Enter your security code by visiting https://g.co/sc: ") != PAM_SUCCESS) {
       pam_error(pamh, "Unable to get user input");
       return PAM_PERM_DENIED;
     }


### PR DESCRIPTION
Customer's request (b/278036791):

Current OS login SSH flow displays to a user the following prompt to provide the OTP:
`Enter your security code by visiting g.co/sc:`
This is cumbersome as one can't access the service directly from the terminal by eg. cmd+double-click on MacOS.
If the user were provided the full URL like shown below it would make the job easier:
`Enter your security code by visiting https://g.co/sc:`
