### PR TITLE
sshca: support method token and handle multi line

### DIFF
--- a/src/pam/oslogin_sshca.cc
+++ b/src/pam/oslogin_sshca.cc
@@ -24,25 +24,25 @@ typedef struct sshca_type {
   int (*skip_custom_fields)(char **buff, size_t *blen);
 } sshca_type;
 
-static int sshca_dsa_skip_fields(char **buff, size_t *blen);
-static int sshca_ecdsa_skip_fields(char **buff, size_t *blen);
-static int sshca_ed25519_skip_fields(char **buff, size_t *blen);
-static int sshca_rsa_skip_fields(char **buff, size_t *blen);
+static int _sshca_dsa_skip_fields(char **buff, size_t *blen);
+static int _sshca_ecdsa_skip_fields(char **buff, size_t *blen);
+static int _sshca_ed25519_skip_fields(char **buff, size_t *blen);
+static int _sshca_rsa_skip_fields(char **buff, size_t *blen);
 
 static sshca_type sshca_impl[] = {
-    {"ecdsa-sha2-nistp256-cert-v01@openssh.com", sshca_ecdsa_skip_fields},
-    {"ecdsa-sha2-nistp384-cert-v01@openssh.com", sshca_ecdsa_skip_fields},
-    {"ecdsa-sha2-nistp521-cert-v01@openssh.com", sshca_ecdsa_skip_fields},
-    {"rsa-sha2-256-cert-v01@openssh.com", sshca_rsa_skip_fields},
-    {"rsa-sha2-512-cert-v01@openssh.com", sshca_rsa_skip_fields},
-    {"ssh-dss-cert-v01@openssh.com", sshca_dsa_skip_fields},
-    {"ssh-ed25519-cert-v01@openssh.com", sshca_ed25519_skip_fields},
-    {"ssh-rsa-cert-v01@openssh.com", sshca_rsa_skip_fields},
+    {"ecdsa-sha2-nistp256-cert-v01@openssh.com", _sshca_ecdsa_skip_fields},
+    {"ecdsa-sha2-nistp384-cert-v01@openssh.com", _sshca_ecdsa_skip_fields},
+    {"ecdsa-sha2-nistp521-cert-v01@openssh.com", _sshca_ecdsa_skip_fields},
+    {"rsa-sha2-256-cert-v01@openssh.com", _sshca_rsa_skip_fields},
+    {"rsa-sha2-512-cert-v01@openssh.com", _sshca_rsa_skip_fields},
+    {"ssh-dss-cert-v01@openssh.com", _sshca_dsa_skip_fields},
+    {"ssh-ed25519-cert-v01@openssh.com", _sshca_ed25519_skip_fields},
+    {"ssh-rsa-cert-v01@openssh.com", _sshca_rsa_skip_fields},
     { },
 };
 
 static int
-sshca_get_string(char **buff, size_t *blen, char **ptr, size_t *len_ptr) {
+_sshca_get_string(char **buff, size_t *blen, char **ptr, size_t *len_ptr) {
   u_int32_t len;
 
   if (*blen < 4) {
@@ -74,7 +74,7 @@ sshca_get_string(char **buff, size_t *blen, char **ptr, size_t *len_ptr) {
 }
 
 static sshca_type*
-sshca_get_implementation(const char *type) {
+_sshca_get_implementation(const char *type) {
   sshca_type *iter;
 
   for (iter = sshca_impl; iter->type != NULL; iter++) {
@@ -87,14 +87,14 @@ sshca_get_implementation(const char *type) {
 }
 
 static int
-sshca_rsa_skip_fields(char **buff, size_t *blen) {
+_sshca_rsa_skip_fields(char **buff, size_t *blen) {
   // Skip e.
-  if (sshca_get_string(buff, blen, NULL, NULL) < 0) {
+  if (_sshca_get_string(buff, blen, NULL, NULL) < 0) {
     return -1;
   }
 
   // Skip n.
-  if (sshca_get_string(buff, blen, NULL, NULL) < 0) {
+  if (_sshca_get_string(buff, blen, NULL, NULL) < 0) {
     return -1;
   }
 
@@ -102,24 +102,24 @@ sshca_rsa_skip_fields(char **buff, size_t *blen) {
 }
 
 static int
-sshca_dsa_skip_fields(char **buff, size_t *blen) {
+_sshca_dsa_skip_fields(char **buff, size_t *blen) {
   // Skip p.
-  if (sshca_get_string(buff, blen, NULL, NULL) < 0) {
+  if (_sshca_get_string(buff, blen, NULL, NULL) < 0) {
     return -1;
   }
 
   // Skip q.
-  if (sshca_get_string(buff, blen, NULL, NULL) < 0) {
+  if (_sshca_get_string(buff, blen, NULL, NULL) < 0) {
     return -1;
   }
 
   // Skip g.
-  if (sshca_get_string(buff, blen, NULL, NULL) < 0) {
+  if (_sshca_get_string(buff, blen, NULL, NULL) < 0) {
     return -1;
   }
 
   // Skip y.
-  if (sshca_get_string(buff, blen, NULL, NULL) < 0) {
+  if (_sshca_get_string(buff, blen, NULL, NULL) < 0) {
     return -1;
   }
 
@@ -127,20 +127,20 @@ sshca_dsa_skip_fields(char **buff, size_t *blen) {
 }
 
 static int
-sshca_ed25519_skip_fields(char **buff, size_t *blen) {
+_sshca_ed25519_skip_fields(char **buff, size_t *blen) {
   // Skip pk.
-  return sshca_get_string(buff, blen, NULL, NULL);
+  return _sshca_get_string(buff, blen, NULL, NULL);
 }
 
 static int
-sshca_ecdsa_skip_fields(char **buff, size_t *blen) {
+_sshca_ecdsa_skip_fields(char **buff, size_t *blen) {
   // Skip curve.
-  if (sshca_get_string(buff, blen, NULL, NULL) < 0) {
+  if (_sshca_get_string(buff, blen, NULL, NULL) < 0) {
     return -1;
   }
 
   // Skip public key.
-  if (sshca_get_string(buff, blen, NULL, NULL) < 0) {
+  if (_sshca_get_string(buff, blen, NULL, NULL) < 0) {
     return -1;
   }
 
@@ -148,7 +148,7 @@ sshca_ecdsa_skip_fields(char **buff, size_t *blen) {
 }
 
 static int
-sshca_get_extension(pam_handle_t *pamh, const char *key, size_t k_len, char **exts) {
+_sshca_get_extension(pam_handle_t *pamh, const char *key, size_t k_len, char **exts) {
   sshca_type* impl = NULL;
   size_t n_len, t_len, tmp_exts_len, ret = -1;
   char *tmp_exts, *tmp_head, *type, *key_b64, *head;
@@ -171,19 +171,19 @@ sshca_get_extension(pam_handle_t *pamh, const char *key, size_t k_len, char **ex
     goto out;
   }
 
-  if (sshca_get_string(&key_b64, &n_len, &type, &t_len) < 0) {
+  if (_sshca_get_string(&key_b64, &n_len, &type, &t_len) < 0) {
     PAM_SYSLOG(pamh, LOG_ERR, "Could not get cert's type string.");
     goto out;
   }
 
-  impl = sshca_get_implementation(type);
+  impl = _sshca_get_implementation(type);
   if (impl == NULL) {
     PAM_SYSLOG(pamh, LOG_ERR, "Invalid cert type: %s.", type);
     goto out;
   }
 
   // Skip nonce for all types of certificates.
-  if (sshca_get_string(&key_b64, &n_len, NULL, NULL) < 0) {
+  if (_sshca_get_string(&key_b64, &n_len, NULL, NULL) < 0) {
     PAM_SYSLOG(pamh, LOG_ERR, "Failed to skip cert's \"nonce\" field.");
     goto out;
   }
@@ -201,13 +201,13 @@ sshca_get_extension(pam_handle_t *pamh, const char *key, size_t k_len, char **ex
   SKIP_UINT32(key_b64, n_len);
 
   // Skip key id.
-  if (sshca_get_string(&key_b64, &n_len, NULL, NULL) < 0) {
+  if (_sshca_get_string(&key_b64, &n_len, NULL, NULL) < 0) {
     PAM_SYSLOG(pamh, LOG_ERR, "Failed to skip cert's \"key id\" field.");
     goto out;
   }
 
   // Skip valid principals.
-  if (sshca_get_string(&key_b64, &n_len, NULL, NULL) < 0) {
+  if (_sshca_get_string(&key_b64, &n_len, NULL, NULL) < 0) {
     PAM_SYSLOG(pamh, LOG_ERR, "Failed to skip cert's \"valid principals\" "
                "field.");
     goto out;
@@ -220,21 +220,21 @@ sshca_get_extension(pam_handle_t *pamh, const char *key, size_t k_len, char **ex
   SKIP_UINT64(key_b64, n_len);
 
   // Skip critical options.
-  if (sshca_get_string(&key_b64, &n_len, NULL, NULL) < 0) {
+  if (_sshca_get_string(&key_b64, &n_len, NULL, NULL) < 0) {
     PAM_SYSLOG(pamh, LOG_ERR, "Failed to skip cert's \"critical options\" "
                "field.");
     goto out;
   }
 
   // Get extensions buffer.
-  if (sshca_get_string(&key_b64, &n_len, &tmp_exts, &tmp_exts_len) < 0) {
+  if (_sshca_get_string(&key_b64, &n_len, &tmp_exts, &tmp_exts_len) < 0) {
     PAM_SYSLOG(pamh, LOG_ERR, "Failed to get cert's \"extensions\" field.");
     goto out;
   }
 
   // The field extensions is a self described/sized buffer.
   tmp_head = tmp_exts;
-  if (sshca_get_string(&tmp_exts, &tmp_exts_len, exts, &ret) < 0) {
+  if (_sshca_get_string(&tmp_exts, &tmp_exts_len, exts, &ret) < 0) {
     PAM_SYSLOG(pamh, LOG_ERR, "Failed to read google's extension.");
     goto out;
   }
@@ -248,28 +248,31 @@ out:
 }
 
 static size_t
-sshca_split_key(const char *blob, char **out) {
-  int i, len, k_start;
+_sshca_split_key(const char *blob, char **out) {
+  int i, len, algo_start, k_start;
   char *key = NULL;
 
-  len = 0;
-  k_start = 0;
+  len, k_start, algo_start = 0;
 
   for (i = 0; blob[i] != '\0'; i++) {
     if (blob[i] == ' ' && key == NULL) {
-      k_start = i + 1;
-      key = (char *)blob + i + 1;
+      if (!algo_start) {
+        algo_start = i;
+      } else {
+        k_start = i + 1;
+        key = (char *)blob + i + 1;
+      }
     } else if (blob[i] == ' ' && key != NULL) {
       len = i;
     }
   }
 
   *out = strndup(key, len - k_start);
-  return len;
+  return strlen(*out);
 }
 
 static size_t
-sshca_extract_fingerprint(const char *extension, char **out) {
+_sshca_extract_fingerprint(const char *extension, char **out) {
   int i = 0;
 
   if (extension == NULL || strstr(extension, "fingerprint@google.com=") == NULL) {
@@ -285,27 +288,27 @@ sshca_extract_fingerprint(const char *extension, char **out) {
   return i;
 }
 
-int
-sshca_get_byoid_fingerprint(pam_handle_t *pamh, const char *blob, char **fingerprint) {
+static int
+_sshca_get_byoid_fingerprint(pam_handle_t *pamh, const char *blob, char **fingerprint) {
   size_t f_len, k_len, exts_len = -1;
   char *key, *exts = NULL;
 
-  k_len = sshca_split_key(blob, &key);
+  k_len = _sshca_split_key(blob, &key);
   if (k_len <= 0) {
     PAM_SYSLOG(pamh, LOG_ERR, "Could not split ssh ca cert.");
     goto out;
   }
 
-  exts_len = sshca_get_extension(pamh, key, k_len, &exts);
+  exts_len = _sshca_get_extension(pamh, key, k_len, &exts);
   if (exts_len < 0) {
-    PAM_SYSLOG(pamh, LOG_ERR, "Could not parse/extract extension"
+    PAM_SYSLOG(pamh, LOG_ERR, "Could not parse/extract extension "
                "from ssh ca cert.");
     goto out;
   }
 
-  f_len = sshca_extract_fingerprint(exts, fingerprint);
+  f_len = _sshca_extract_fingerprint(exts, fingerprint);
   if (f_len == 0) {
-    PAM_SYSLOG(pamh, LOG_ERR, "Could not parse/extract fingerprint"
+    PAM_SYSLOG(pamh, LOG_ERR, "Could not parse/extract fingerprint "
                "from ssh ca cert's extension.");
     goto out;
   }
@@ -313,6 +316,33 @@ sshca_get_byoid_fingerprint(pam_handle_t *pamh, const char *blob, char **fingerp
 out:
   free(exts);
   free(key);
+
+  return f_len;
+}
+
+int
+sshca_get_byoid_fingerprint(pam_handle_t *pamh, const char *blob, char **fingerprint) {
+  char *line, *saveptr = NULL;
+  size_t f_len = 0;
+
+  if (blob == NULL || strlen(blob) == 0) {
+    PAM_SYSLOG(pamh, LOG_ERR, "Could not parse/extract fingerprint "
+               "from ssh ca cert's extension: \"blob\" is empty.");
+  }
+
+  if (fingerprint == NULL) {
+    PAM_SYSLOG(pamh, LOG_ERR, "Could not parse/extract fingerprint "
+               "from ssh ca cert's extension: \"fingerprint\" is NULL.");
+  }
+
+  line = strtok_r((char *)blob, "\n", &saveptr);
+  while (line != NULL) {
+    f_len = _sshca_get_byoid_fingerprint(pamh, line, fingerprint);
+    if (f_len > 0) {
+      return f_len;
+    }
+    line = strtok_r(NULL, "\n", &saveptr);
+  }
 
   return f_len;
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,7 +7,7 @@ endif
 TEST_RUNNER = ./test_runner --gtest_output=xml
 NEW_TEST_RUNNER = ./new_test_runner --gtest_output=xml
 SSHCA_TEST_RUNNER = ./sshca_runner --gtest_output=xml --gtest_filter="SSHCATests.*"
-CPPFLAGS += -I$(TOPDIR)/src/include -I/usr/include/json-c -I$(GTEST_DIR) -isystem $(GTEST_DIR)/include
+CPPFLAGS += -I$(TOPDIR)/src/include -I$(TOPDIR)/third_party/include -I/usr/include/json-c -I$(GTEST_DIR) -isystem $(GTEST_DIR)/include
 CXXFLAGS += -g -Wall -Wextra -std=c++11
 LDLIBS = -lcurl -ljson-c -lpthread
 

--- a/test/oslogin_sshca_test.cc
+++ b/test/oslogin_sshca_test.cc
@@ -23,7 +23,7 @@ using std::vector;
 
 namespace oslogin_utils {
 
-#define VALID_ECDSA_SINGLE_EXT "ecdsa-sha2-nistp256-cert-v01@openssh.com " \
+#define VALID_ECDSA_SINGLE_EXT "publickey ecdsa-sha2-nistp256-cert-v01@openssh.com " \
   "AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3BlbnNzaC5jb20AAAAg1yMhf" \
   "NVBe4etWEQNDmtxhsAD+YAb7fl/Bn0Z+GGEE9EAAAAIbmlzdHAyNTYAAABBBJ+nM2cR4B" \
   "FHbmokUIScpTaSkx/F1QS2KfIx6z4wcpUmjzKtbP0KFw12mMUiNHzlNBD0B2RnX54uN+k" \
@@ -48,7 +48,7 @@ namespace oslogin_utils {
   "bcetrgglFiujUFlIdxkHMmsIxHM88wEnJAlETd7zl9WR/FgQYn3y2dZz9VKoheJdg== "  \
   "pantheon.sitar.mig"                                                    \
 
-#define INVALID_ECDSA_NO_FP "ecdsa-sha2-nistp256-cert-v01@openssh.com A" \
+#define INVALID_ECDSA_NO_FP "publickey ecdsa-sha2-nistp256-cert-v01@openssh.com A" \
   "AAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgxlbtL" \
   "/mjYXEgsXjl7GZgpvIFncxbfmjPYVewm1sdXo4AAAAIbmlzdHAyNTYAAABBBMYdGLr6M" \
   "102qgBeJ3CanDi0WV1vGif2jMMv1ldtN0+wbDztYdtUu8iop/tN46wFVbfmSzyx/R2YL" \
@@ -60,12 +60,12 @@ namespace oslogin_utils {
   "pM3dlil8jDXlpL4U1JSmP3MeHX0OKcpHgAAACAYiWa3KrreEzN+VrnuhwStH70bvH9Qm" \
   "6Va6a0IcMrMkA== fingerprint@google.com"                               \
 
-#define INVALID_ECDSA_NON_CERT "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI" \
+#define INVALID_ECDSA_NON_CERT "publickey ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI" \
   "tbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMYdGLr6M102qgBeJ3CanDi0WV1vGif2jMM" \
   "v1ldtN0+wbDztYdtUu8iop/tN46wFVbfmSzyx/R2YLbvQ+z2k/sY= "               \
   "fingerprint@google.com"                                               \
 
-#define VALID_RSA_SINGLE_EXT "ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc" \
+#define VALID_RSA_SINGLE_EXT "publickey ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc" \
   "2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgijvX6FIu7BjRIACC+C0b8cxrAORm8flzJU" \
   "3Y2q7ci/4AAAADAQABAAABAQCU/mydd9mSwlSDv4T3OiL5IHrvSuXpWFvCEDmVyLxBHz1" \
   "FCwjnk3G5xSt9nGtUyL0KpGt0dyvLU07JGB33cbVnVe1z3373FNKxF8LdwDTEZG6xijXu" \
@@ -98,7 +98,7 @@ namespace oslogin_utils {
   "IBVqgGgEztsSYO0brQWsCoiOxToxWiqDbYc2ifgcIUB+kSzvmbkvbgoNuT111PKpMkIii" \
   "GqmJpNjwsqExxW5E= fingerprint@google.com"                              \
 
-#define INVALID_RSA_NO_FP "ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2Et" \
+#define INVALID_RSA_NO_FP "publickey ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2Et" \
   "Y2VydC12MDFAb3BlbnNzaC5jb20AAAAgwCArEN+qa2BR5+4DNaSCwGP3avz3wFcJzuaZk" \
   "UrXsv0AAAADAQABAAABAQCic3UBNOW41D6BH8e8acBKAw3PdWcvqEIP8v5Otk56nXNrZH" \
   "8tTrposPHZOjAoMCyv9F3siuv+ZfX8k0/x2l9Efayhdcr8AWIr+riqYBNHUby7iefdXCR" \
@@ -130,7 +130,7 @@ namespace oslogin_utils {
   "6tN/eIqzpsfLbRPoK4B7xmoEqtPn1KidKZnvegGasSfrquoyM/E4enhV3kXfJQ== "     \
   "fingerprint@google.com"                                                \
 
-#define INVALID_RSA_NON_CERT "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCU/m" \
+#define INVALID_RSA_NON_CERT "publickey ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCU/m" \
   "ydd9mSwlSDv4T3OiL5IHrvSuXpWFvCEDmVyLxBHz1FCwjnk3G5xSt9nGtUyL0KpGt0dyv" \
   "LU07JGB33cbVnVe1z3373FNKxF8LdwDTEZG6xijXuOi4xfk47arlpk9Pw14qcnVu9on4R" \
   "m4cSmm5PkyIwTfJsKvOl8oOgZ0HZG7pzYEt+9wUoeGzUE0rsAreNFVB7ZBqHp2ZtdIe5d" \
@@ -138,7 +138,7 @@ namespace oslogin_utils {
   "NZPchE/T19LSP/fQbPCGmqc+mC6YodSEbLkO6JmOaW+knTEc9D6xdozx6Oa4vR "       \
   "fingerprint@google.com"                                                \
 
-#define VALID_DSA_SINGLE_EXT "ssh-dss-cert-v01@openssh.com AAAAHHNzaC1kc" \
+#define VALID_DSA_SINGLE_EXT "publickey ssh-dss-cert-v01@openssh.com AAAAHHNzaC1kc" \
   "3MtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgH400e9SzsvaN8OkKvH26sXEJtU/BVc2IBG" \
   "fdZDHk508AAACBAO9UdOmq7Z0qy86mwsDf07TmXQe7X0TLKbyFSsd2b+jTCzpXy9rBhgg" \
   "oJlzYzxSQgtR4JaSTauZMiQQViN3cKvHuGfAXIOIMtMHVupNy6WSkcixGrvw6Y0Yr90+e" \
@@ -163,7 +163,7 @@ namespace oslogin_utils {
   "AAAAdzc2gtZHNzAAAAKH5faM5YTlMn+h2cf99PJ8rjvqQUJoh5yi3a4pkGcr5MJs53Wfi" \
   "DPaA= fingerprint@google.com"                                          \
 
-#define INVALID_DSA_NO_FP "ssh-dss-cert-v01@openssh.com AAAAHHNzaC1kc3Mt" \
+#define INVALID_DSA_NO_FP "publickey ssh-dss-cert-v01@openssh.com AAAAHHNzaC1kc3Mt" \
   "Y2VydC12MDFAb3BlbnNzaC5jb20AAAAgGrlYnOqQxs/zzfWRcrM7DHrFy653/x7rtOghw" \
   "R/f3HIAAACBALzWA8yWLownZsO4Tuc4DF6EplCJ1SBSEqMYAEhzrnxjHkoOpJ3Ncs+Zn5" \
   "jdcnCamkm6KQ4keXkV0xwLthRgLxhUguc9xANV5k2Vft+axWr+cp+KNiGzDjblTUnWzQD" \
@@ -187,7 +187,7 @@ namespace oslogin_utils {
   "+YzrU7BOR7qnGs1qJqWhgFKXETMeHxPzpi4ny9tSNlI6c0g= "                     \
   "fingerprint@google.com"                                                \
 
-#define INVALID_DSA_NON_CERT "ssh-dss AAAAB3NzaC1kc3MAAACBAO9UdOmq7Z0qy8" \
+#define INVALID_DSA_NON_CERT "publickey ssh-dss AAAAB3NzaC1kc3MAAACBAO9UdOmq7Z0qy8" \
   "6mwsDf07TmXQe7X0TLKbyFSsd2b+jTCzpXy9rBhggoJlzYzxSQgtR4JaSTauZMiQQViN3" \
   "cKvHuGfAXIOIMtMHVupNy6WSkcixGrvw6Y0Yr90+e8PXcFw6jwQbFZX4v9zlUuIl067rC" \
   "rxp1jnhBjxvBZEmpR/ezAAAAFQCO10V2wYXJ7cSo4eEgHB1BnOxbzwAAAIEAzbdt5bgzV" \
@@ -198,7 +198,7 @@ namespace oslogin_utils {
   "kN0PeT2KtyGWqLcnbFRSQGNQOs+vv3TIUofZosXKTA2EtmjpKcIbfu3lF+J50g= "      \
   "fingerprint@google.com"                                                \
 
-#define VALID_ED25519_SINGLE_EXT "ssh-ed25519-cert-v01@openssh.com AAAAI" \
+#define VALID_ED25519_SINGLE_EXT "publickey ssh-ed25519-cert-v01@openssh.com AAAAI" \
   "HNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIDaErnQWEw/jxPD0JUJsEk" \
   "CtENcE11Zl53QHbxbAgx22AAAAIHs6r2AekiTHmmoJMKxAKtKW4qcGq5Ku1+SJ1NLdZh0" \
   "1AAAAAAAAAAAAAAABAAAAFmZpbmdlcnByaW50QGdvb2dsZS5jb20AAAAaAAAAFmZpbmdl" \
@@ -209,7 +209,7 @@ namespace oslogin_utils {
   "Yv0T0U/GZoCiLfVm3pcXV3RA8aze+y/pbjv+MOxjmAb4KbRH31/S34UALsyGwQM= fing" \
   "erprint@google.com"                                                    \
 
-#define INVALID_ED25519_NO_FP "ssh-ed25519-cert-v01@openssh.com AAAAIHNz" \
+#define INVALID_ED25519_NO_FP "publickey ssh-ed25519-cert-v01@openssh.com AAAAIHNz" \
   "aC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIDDgIXa9QLFY7RpSNnWDm3Saq" \
   "YZ5HGcpzHq9hdv64nqXAAAAIKfDRdZjpCb2YVsmhs286hQTH7JFctizNC0W7UQKfruSAA" \
   "AAAAAAAAAAAAABAAAAFmZpbmdlcnByaW50QGdvb2dsZS5jb20AAAAaAAAAFmZpbmdlcnB" \
@@ -218,7 +218,7 @@ namespace oslogin_utils {
   "AALc3NoLWVkMjU1MTkAAABAt2CPRZos3Lna+44LwI6ON8rRktxAqz1S4nUf+IwrG83Wbv" \
   "nEvvZ2plHLTAU7GP2ZMedVKoXB9KXB2vNBVjt9Cg== fingerprint@google.com"     \
 
-#define INVALID_ED25519_NON_CERT "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH" \
+#define INVALID_ED25519_NON_CERT "publickey ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH" \
   "s6r2AekiTHmmoJMKxAKtKW4qcGq5Ku1+SJ1NLdZh01 fingerprint@google.com"     \
 
 TEST(SSHCATests, TestValidSingleExtCert) {


### PR DESCRIPTION
We didn't account that the SSH_AUTH_INFO_0 variable format has a method
token and that it can have multiple lines - even that it's unlikely
to happen with oslogin use cases it's healthier to account for that.

The tests were changed to reflect the actual implementation change.

Additionally this patch also changes the internal function's signature
to be prefixed with _.