### PR TITLE
utils: change FileExists() to use stat() instead of access()

### DIFF
--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -1279,7 +1279,8 @@ static bool ApplyPolicy(const char *user_name, string email, const char *policy,
 }
 
 static bool FileExists(const char *file_path) {
-  return access(file_path, F_OK) == 0;
+  struct stat buff;
+  return !stat(file_path, &buff);
 }
 
 static bool CreateGoogleUserFile(string users_filename) {


### PR DESCRIPTION
We observed an inconsistency of behavior of access() across linux systems, to work that around we are changing it to use stat() instead.