### PR TITLE
build: fix suse build

### DIFF
--- a/src/include/oslogin_utils.h
+++ b/src/include/oslogin_utils.h
@@ -16,6 +16,8 @@
 #include <pthread.h>
 #include <pwd.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <syslog.h>
 
 #include <string>


### PR DESCRIPTION
Given the current headers included and suse 12's headers current state we'll end up not having stdio.h and stdlib.h in cases we expect them to be available so we need to explicitly include them.