### PR TITLE
packaging: make the dependency explicit

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9), libcurl4-openssl-dev, libjson-c-dev | libjson0-
 
 Package: google-compute-engine-oslogin
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, google-guest-agent (>= 1:20231003)
 Description: Google Compute Engine OS Login
  Contains libraries, applications and configurations for using OS Login
  on Google Compute Engine Virtual Machine Instances.

--- a/packaging/google-compute-engine-oslogin.spec
+++ b/packaging/google-compute-engine-oslogin.spec
@@ -25,6 +25,7 @@ Summary:        OS Login Functionality for Google Compute Engine
 
 License:        ASL 2.0
 Source0:        %{name}_%{version}.orig.tar.gz
+Requires:       google-guest-agent >= 1:20231003
 
 BuildRequires:  boost-devel
 BuildRequires:  gcc-c++


### PR DESCRIPTION
Force guest-agent to be present in at least a given version.