### PR TITLE
Take metadata endpoint from config file

### DIFF
--- a/src/include/oslogin_utils.h
+++ b/src/include/oslogin_utils.h
@@ -51,8 +51,7 @@ using std::vector;
 namespace oslogin_utils {
 
 // Metadata server URL.
-static const char kMetadataServerUrl[] =
-    "http://169.254.169.254/computeMetadata/v1/oslogin/";
+extern const char * kMetadataServerUrl;
 
 // BufferManager encapsulates and manages a buffer and length. This class is not
 // thread safe.


### PR DESCRIPTION
Config file /etc/google_oslogin.conf
Example content:
endpoint: localhost:6770

Keep default behaviour in case no config.
