### PR TITLE
Update packaging as of Ubuntu devel packaging

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,13 +1,22 @@
 Source: google-compute-engine-oslogin
 Maintainer: Google Cloud Team <gc-team@google.com>
-Section: misc
+Section: admin
 Priority: optional
-Standards-Version: 3.9.8
-Build-Depends: debhelper (>= 9), libcurl4-openssl-dev, libjson-c-dev | libjson0-dev, libpam-dev
+Build-Depends: cmake,
+               debhelper-compat (= 12),
+               libcurl4-openssl-dev,
+               libgtest-dev,
+               libjson-c-dev,
+               libpam-dev
+Standards-Version: 4.5.0
+Homepage: https://github.com/GoogleCloudPlatform/compute-image-packages
 
 Package: google-compute-engine-oslogin
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, google-guest-agent (>= 1:20231003)
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         openssh-server,
+         google-guest-agent (>= 20231004.02)
 Description: Google Compute Engine OS Login
  Contains libraries, applications and configurations for using OS Login
  on Google Compute Engine Virtual Machine Instances.

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,13 +1,32 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: google-compute-engine-oslogin
-Upstream-Contact: gc-team@google.com
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: compute-image-packages
+Upstream-Contact: Google Corp <https://github.com/GoogleCloudPlatform>
+Source: https://github.com/GoogleCloudPlatform/guest-oslogin
 
 Files: *
-Copyright: Copyright 2017 Google Inc.
+Copyright: 2017-2020, Google Inc
 License: Apache-2.0
 
+Files: LICENSE
+       packaging/debian/copyright
+       packaging/google-compute-engine-oslogin.spec
+       src/authorized_keys/*
+       src/cache_refresh/*
+       src/include/*
+       src/nss/*
+       src/oslogin_utils.cc
+       src/pam/*
+       test/oslogin_utils_test.cc
+Copyright: 2017-2020, Google Inc
+License: Apache-2.0
+
+Files: src/nss/compat/*
+Copyright: 2015, Kevin Bowling <k@kev009.com>
+           2005-2014, Rich Felker
+License: Expat
+
 Files: debian/*
-Copyright: Copyright 2017 Google Inc.
+Copyright: 2017-2020, Canonical Group, Ltd
 License: Apache-2.0
 
 License: Apache-2.0
@@ -15,7 +34,7 @@ License: Apache-2.0
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
  .
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
  .
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,3 +44,25 @@ License: Apache-2.0
  .
  On Debian systems, the complete text of the Apache version 2.0 license
  can be found in "/usr/share/common-licenses/Apache-2.0".
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+

--- a/packaging/debian/docs
+++ b/packaging/debian/docs
@@ -1,0 +1,1 @@
+README.md

--- a/packaging/debian/links
+++ b/packaging/debian/links
@@ -1,0 +1,2 @@
+lib/libnss_cache_oslogin-20231004.00.so lib/libnss_cache_oslogin.so.2
+lib/libnss_oslogin-20231004.00.so lib/libnss_oslogin.so.2

--- a/packaging/debian/lintian-overrides
+++ b/packaging/debian/lintian-overrides
@@ -1,0 +1,8 @@
+# prerm is not exactly empty, it always succeed fixing broken old ones
+google-compute-engine-oslogin: maintainer-script-empty prerm
+# upstream does not provide manpages for those instrastructure scripts
+google-compute-engine-oslogin: no-manual-page [usr/bin/google_authorized_keys]
+google-compute-engine-oslogin: no-manual-page [usr/bin/google_authorized_keys_sk]
+google-compute-engine-oslogin: no-manual-page [usr/bin/google_oslogin_nss_cache]
+# wontfix, ther is no plan to split the shared libraries out of the package
+google-compute-engine-oslogin: package-name-doesnt-match-sonames libnss-cache-oslogin2 libnss-oslogin2

--- a/packaging/debian/patches/0001-set-LDFLAGS-to-prevent-undefs.patch
+++ b/packaging/debian/patches/0001-set-LDFLAGS-to-prevent-undefs.patch
@@ -1,0 +1,24 @@
+From: Brian Murray <brian@ubuntu.com>
+Date: Fri, 12 Apr 2019 13:23:42 +0200
+Subject: set LDFLAGS to report unresolved symbol references
+
+Origin: Ubuntu
+Forwarded: no
+Last-Update: 2018-11-08
+---
+ src/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index 4d1dde1..5f63948 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -6,7 +6,7 @@ FLAGS = -fPIC -Wall -g
+ CFLAGS = $(FLAGS) -Wstrict-prototypes
+ CXXFLAGS = $(FLAGS)
+ 
+-LDFLAGS = -shared -Wl,-soname,$(SONAME)
++LDFLAGS = -shared -Wl,-z,defs -Wl,-soname,$(SONAME)
+ LDLIBS = -lcurl -ljson-c
+ PAMLIBS = -lpam $(LDLIBS)
+ 

--- a/packaging/debian/patches/series
+++ b/packaging/debian/patches/series
@@ -1,0 +1,1 @@
+0001-set-LDFLAGS-to-prevent-undefs.patch

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+#DEBHELPER#
+
+# In version 20170718-0ubuntu1 prerm disabled OS Login but the package did not
+# depend on openssh-server and missing openssh-server made disabling OS Login
+# and as a result prerm fail. Upon upgrading google-compute-engine-oslogin dpkg
+# tried to fall back to running the new version's prerm but it failed since it
+# was missing. (LP: #1733878)
+# This minimal prerm just exits with success making upgrading from
+# 20170718-0ubuntu1 and older releases succeed.
+exit 0

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,12 +1,25 @@
 #!/usr/bin/make -f
+
+DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+
+export VERSION=$(shell dpkg-parsechangelog -S Version | sed 's/-.*//')
+
 %:
-	dh $@ --with=systemd
+	dh $@
+
+override_dh_auto_configure:
+	cp -r /usr/src/gtest/ ./
+	dh_auto_configure
+
+override_dh_auto_test:
+	(cd gtest && cmake . && $(MAKE) )
+	make -C test CXXFLAGS="$(CXXFLAGS) -I$(CURDIR)/gtest" GTEST_DIR=$(CURDIR)/gtest
 
 override_dh_auto_install:
-	dh_auto_install -- LIBDIR=/lib/$(DEB_HOST_MULTIARCH) VERSION=$(VERSION)
+	$(MAKE) DESTDIR=$(CURDIR)/debian/google-compute-engine-oslogin LIBDIR=/lib PAMDIR=/lib/$(DEB_HOST_MULTIARCH)/security install
 
-override_dh_systemd_enable:
-	dh_systemd_enable google-oslogin-cache.timer
+override_dh_installsystemd:
+	dh_installsystemd google-oslogin-cache.timer
 
-override_dh_systemd_start:
-	dh_systemd_start google-oslogin-cache.timer
+override_dh_clean:
+	dh_clean gtest/

--- a/packaging/debian/watch
+++ b/packaging/debian/watch
@@ -1,0 +1,8 @@
+# Compulsory line, this is a version 4 file
+version=4
+
+opts=\
+compression=xz,\
+dversionmangle=s/[-.+~]?(git|snapshot|repack|dfsg)(.*)$//i,\
+filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/google-compute-engine-oslogin-$1\.tar\.gz/ \
+ https://github.com/GoogleCloudPlatform/guest-oslogin/tags .*/v?(\d\S*)\.tar\.gz


### PR DESCRIPTION
Hello,

This PR is an initiative to align the Debian packaging of guest-oslogin in Ubuntu and upstream (here).

The diff represents the changes we have in Ubuntu. I'm forwarding them here as they're all relevant and follow the standard Debian packaging practices. These changes are what we have in Ubuntu devel (current development branch).

These changes change how packaging is done and don't affect the resulting binaries (that is, there is no functional change).

Please let me know if you have any questions or concerns.
