### PR TITLE
pam: bring back pam's account management implementation

### DIFF
--- a/packaging/google-compute-engine-oslogin.spec
+++ b/packaging/google-compute-engine-oslogin.spec
@@ -67,6 +67,7 @@ make install DESTDIR=%{buildroot} LIBDIR=/%{_lib} VERSION=%{version} INSTALL_SEL
 /%{_lib}/libnss_cache_oslogin-%{version}.so
 /%{_lib}/libnss_oslogin.so.2
 /%{_lib}/libnss_cache_oslogin.so.2
+/%{_lib}/security/pam_oslogin_admin.so
 /%{_lib}/security/pam_oslogin_login.so
 /usr/bin/google_authorized_keys
 /usr/bin/google_authorized_keys_sk

--- a/src/Makefile
+++ b/src/Makefile
@@ -47,6 +47,7 @@ NSS_CACHE_OSLOGIN_SONAME = libnss_cache_oslogin.so.2
 NSS_OSLOGIN              = libnss_oslogin-$(VERSION).so
 NSS_CACHE_OSLOGIN        = libnss_cache_oslogin-$(VERSION).so
 
+PAM_ADMIN                = pam_oslogin_admin.so
 PAM_LOGIN                = pam_oslogin_login.so
 
 BINARIES = google_oslogin_nss_cache google_authorized_keys google_authorized_keys_sk google_authorized_principals
@@ -54,7 +55,7 @@ BINARIES = google_oslogin_nss_cache google_authorized_keys google_authorized_key
 .PHONY: all clean install
 .DEFAULT_GOAL := all
 
-all: $(NSS_OSLOGIN) $(NSS_CACHE_OSLOGIN) $(PAM_LOGIN) $(BINARIES)
+all: $(NSS_OSLOGIN) $(NSS_CACHE_OSLOGIN) $(PAM_LOGIN) $(PAM_ADMIN) $(BINARIES)
 
 clean:
 	rm -f $(BINARIES)
@@ -73,6 +74,9 @@ $(NSS_CACHE_OSLOGIN): nss/nss_cache_oslogin.o nss/compat/getpwent_r.o oslogin_ut
 # PAM modules
 
 $(PAM_LOGIN): pam/pam_oslogin_login.o oslogin_sshca.o oslogin_utils.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -shared $^ -o $@ $(PAMLIBS)
+
+$(PAM_ADMIN): pam/pam_oslogin_admin.o oslogin_sshca.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -shared $^ -o $@ $(PAMLIBS)
 
 # Utilities.
@@ -100,7 +104,7 @@ install: all
 	ln -sf $(NSS_OSLOGIN)         $(DEST_LIBDIR)/$(NSS_OSLOGIN_SONAME)
 	ln -sf $(NSS_CACHE_OSLOGIN)   $(DEST_LIBDIR)/$(NSS_CACHE_OSLOGIN_SONAME)
 	# PAM modules
-	install -m 0644 -t $(DEST_PAMDIR) $(PAM_LOGIN)
+	install -m 0644 -t $(DEST_PAMDIR) $(PAM_LOGIN) $(PAM_ADMIN)
 	# Binaries
 	install -m 0755 -t $(DEST_BINDIR) $(BINARIES)
 	# Manpages

--- a/src/include/oslogin_utils.h
+++ b/src/include/oslogin_utils.h
@@ -297,6 +297,11 @@ extern void SysLogErr(const char *fmt, ...);
 
 // AuthoOptions wraps authorization options.
 struct AuthOptions {
+  // admin_policy_required determines if a user is only authorized if admin
+  // policy is available for such a user. i.e. AuthorizeUser() should return
+  // false if adminLogin is not available.
+  bool admin_policy_required;
+
   // security_key determines if the MDS "/users?..." should use
   // the view=securityKey parameter.
   bool security_key;

--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -1388,6 +1388,9 @@ bool AuthorizeUser(const char *user_name, struct AuthOptions opts, string *user_
     }
   } else {
     remove(sudoers_filename.c_str());
+    if (opts.admin_policy_required) {
+      return false;
+    }
   }
 
   return true;

--- a/src/pam/pam_oslogin_admin.cc
+++ b/src/pam/pam_oslogin_admin.cc
@@ -1,0 +1,53 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <security/pam_modules.h>
+
+#include <compat.h>
+#include <oslogin_utils.h>
+
+using std::string;
+
+using oslogin_utils::AuthOptions;
+
+extern "C" {
+
+// pm_sm_acct_mgmt is the account management PAM implementation for admin users (or users
+// with the proper loginAdmin policy). This account management module is intended for custom
+// configuration handling only, where users need a way to in their stack configurations to
+// differentiate a OS Login user. The Google Guest Agent will not manage the lifecycle of
+// this module, it will not add this to the stack as part of the standard/default configuration
+// set.
+PAM_EXTERN int
+pam_sm_acct_mgmt(pam_handle_t* pamh, int flags, int argc, const char** argv) {
+  struct AuthOptions opts;
+  const char *user_name;
+  string user_response;
+
+  if (pam_get_user(pamh, &user_name, NULL) != PAM_SUCCESS) {
+    PAM_SYSLOG(pamh, LOG_INFO, "Could not get pam user.");
+    return PAM_PERM_DENIED;
+  }
+
+  opts = { 0 };
+  opts.admin_policy_required = true;
+
+  if (!AuthorizeUser(user_name, opts, &user_response)) {
+    return PAM_PERM_DENIED;
+  }
+
+  return PAM_SUCCESS;
+}
+
+}


### PR DESCRIPTION
With this change users can get back to using these pam modules for their own custom pam configurations in a way to differentiate oslogin users (i.e. reported issue #123).

PS: These modules will not be automatically added to google's managed pam configurations by guest-agent.