### PR TITLE
Log an error when user has no challenges configured

### DIFF
--- a/src/pam/pam_oslogin_login.cc
+++ b/src/pam/pam_oslogin_login.cc
@@ -111,6 +111,7 @@ pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc,
   }
 
   if (status == "NO_AVAILABLE_CHALLENGES") {
+    PAM_SYSLOG(pamh, LOG_ERR, "User has no two-factor methods enabled.");
     return PAM_PERM_DENIED; // User is not two-factor enabled, deny login.
   }
 


### PR DESCRIPTION
Improves logging when a user doesn't have any 2FA methods configured for their Google account.

Fixes #134
