### PR TITLE
Don't retry bad request responses

### DIFF
--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -422,6 +422,10 @@ bool ShouldRetry(long http_code) {
     // Metadata key does not exist, no point of retrying.
     return false;
   }
+  if (http_code == 400) {
+    // Request parameters are bad, no point of retrying.
+    return false;
+  }
   return true;
 }
 

--- a/test/oslogin_utils_test.cc
+++ b/test/oslogin_utils_test.cc
@@ -463,6 +463,7 @@ TEST(GetGroupByTest, GetGroupByGIDSucceeds) {
 TEST(CurlClient, RetryLogic) {
   ASSERT_FALSE(ShouldRetry(200));
   ASSERT_FALSE(ShouldRetry(404));
+  ASSERT_FALSE(ShouldRetry(400));
   ASSERT_TRUE(ShouldRetry(429));
 }
 


### PR DESCRIPTION
These are returned for incorrect request paramaters (non-utf8, characters not allowed in usernames, etc.) and repeating the request without changing the parameters is pointless. I looked through other return codes from the MDS and no other obviously non-retryable ones jumped out at me other than 405, but 405 would mean there is a logic problem rather than an input problem so we may not want to paper over that one.

Fixes #136

/cc @ericdand @ChaitanyaKulkarni28 