### PR TITLE
Pass c-strings to logging functions

### DIFF
--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -204,7 +204,7 @@ json_object* ParseJsonRoot(const string& json) {
     enum json_tokener_error jerr = json_tokener_get_error(tok);
     string error_message = json_tokener_error_desc(jerr);
     SysLogErr("Failed to parse root JSON element: \"%s\", from input \"%s\"",
-              error_message, json);
+              error_message.c_str(), json.c_str());
   }
 
   json_tokener_free(tok);
@@ -583,7 +583,7 @@ bool ParseJsonToGroups(const string& json, std::vector<Group>* result) {
   json_object* groups;
   json_type groupType;
   if (!json_object_object_get_ex(root, "posixGroups", &groups)) {
-    SysLogErr("failed to parse POSIX groups from \"%s\"", json);
+    SysLogErr("failed to parse POSIX groups from \"%s\"", json.c_str());
     goto cleanup;
   }
   groupType = json_object_get_type(groups);


### PR DESCRIPTION
Hey folks, we're working on updating COS to use the newest version of guest-oslogin and we ran into a compilation issue with strings being passed to the logging functions in src/oslogin_utils.cc since our build pipeline uses clang++.

Specifically, passing a string to a variadic function can fail at runtime, and results in the following error when compiling with clang++: `error: cannot pass object of non-trivial type 'string' (aka 'basic_string<char>') through variadic function; call will abort at runtime`

This fixes the issue by passing c-strings to the relevant functions instead of string.