### PR TITLE
Inherit environment build flags.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,10 +1,10 @@
 SHELL = /bin/sh
 TOPDIR = $(realpath ..)
 
-CPPFLAGS = -Iinclude -I/usr/include/json-c -I$(TOPDIR)/third_party/include
+CPPFLAGS += -Iinclude -I/usr/include/json-c -I$(TOPDIR)/third_party/include
 FLAGS = -fPIC -Wall -g
-CFLAGS = $(FLAGS) -Wstrict-prototypes
-CXXFLAGS = $(FLAGS)
+CFLAGS += $(FLAGS) -Wstrict-prototypes
+CXXFLAGS += $(FLAGS)
 
 LDFLAGS = -shared -Wl,-soname,$(SONAME)
 LDLIBS = -lcurl -ljson-c


### PR DESCRIPTION
This MR addresses https://github.com/GoogleCloudPlatform/guest-oslogin/issues/139 by appending flags in the Makefile  instead of assigning.