### PR TITLE
Follow the Google style guide by using the "local include style" to include files from this project.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/sh
 TOPDIR = $(realpath ..)
 
-CPPFLAGS += -Iinclude -I/usr/include/json-c -I$(TOPDIR)/third_party/include
+CPPFLAGS += -I. -I/usr/include/json-c -I$(TOPDIR)/third_party/include
 FLAGS = -fPIC -Wall -g
 CFLAGS += $(FLAGS) -Wstrict-prototypes
 CXXFLAGS += $(FLAGS)

--- a/src/authorized_keys/authorized_keys.cc
+++ b/src/authorized_keys/authorized_keys.cc
@@ -16,7 +16,7 @@
 
 #include <signal.h>
 
-#include <oslogin_utils.h>
+#include "include/oslogin_utils.h"
 
 using std::cout;
 using std::endl;

--- a/src/authorized_keys/authorized_keys_sk.cc
+++ b/src/authorized_keys/authorized_keys_sk.cc
@@ -17,7 +17,7 @@
 
 #include <signal.h>
 
-#include <oslogin_utils.h>
+#include "include/oslogin_utils.h"
 
 using std::cout;
 using std::endl;

--- a/src/authorized_principals/authorized_principals.cc
+++ b/src/authorized_principals/authorized_principals.cc
@@ -16,8 +16,8 @@
 
 #include <signal.h>
 
-#include <oslogin_utils.h>
-#include <oslogin_sshca.h>
+#include "include/oslogin_utils.h"
+#include "include/oslogin_sshca.h"
 
 using std::cout;
 using std::endl;

--- a/src/cache_refresh/cache_refresh.cc
+++ b/src/cache_refresh/cache_refresh.cc
@@ -25,8 +25,8 @@
 
 #include <fstream>
 
-#include <compat.h>
-#include <oslogin_utils.h>
+#include "include/compat.h"
+#include "include/oslogin_utils.h"
 
 using oslogin_utils::BufferManager;
 using oslogin_utils::MutexLock;

--- a/src/include/oslogin_sshca.h
+++ b/src/include/oslogin_sshca.h
@@ -15,7 +15,7 @@
 #ifndef _OSLOGIN_SSHCA_H_
 #define _OSLOGIN_SSHCA_H_ 1
 
-#include <compat.h>
+#include "include/compat.h"
 #include <ctype.h>
 #include <security/pam_modules.h>
 #include <stdlib.h>

--- a/src/nss/nss_cache_oslogin.c
+++ b/src/nss/nss_cache_oslogin.c
@@ -15,8 +15,8 @@
 // An NSS module which adds supports for file /etc/oslogin_passwd.cache
 
 #include <nss.h>
-#include <nss_cache_oslogin.h>
-#include <compat.h>
+#include "include/nss_cache_oslogin.h"
+#include "include/compat.h"
 
 #include <sys/mman.h>
 #include <time.h>

--- a/src/nss/nss_oslogin.cc
+++ b/src/nss/nss_oslogin.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <compat.h>
-#include <oslogin_utils.h>
+#include "include/compat.h"
+#include "include/oslogin_utils.h"
 
 #include <curl/curl.h>
 #include <errno.h>

--- a/src/oslogin_sshca.cc
+++ b/src/oslogin_sshca.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <oslogin_sshca.h>
-#include <oslogin_utils.h>
+#include "include/oslogin_sshca.h"
+#include "include/oslogin_utils.h"
 #include <openbsd.h>
 
 using oslogin_utils::SysLogErr;

--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -42,8 +42,8 @@
 #define Regex boost
 #endif
 
-#include <compat.h>
-#include <oslogin_utils.h>
+#include "include/compat.h"
+#include "include/oslogin_utils.h"
 
 using std::string;
 

--- a/src/pam/pam_oslogin_admin.cc
+++ b/src/pam/pam_oslogin_admin.cc
@@ -14,8 +14,8 @@
 
 #include <security/pam_modules.h>
 
-#include <compat.h>
-#include <oslogin_utils.h>
+#include "include/compat.h"
+#include "include/oslogin_utils.h"
 
 using std::string;
 

--- a/src/pam/pam_oslogin_login.cc
+++ b/src/pam/pam_oslogin_login.cc
@@ -19,8 +19,8 @@
 #include <sstream>
 #include <map>
 
-#include <compat.h>
-#include <oslogin_utils.h>
+#include "include/compat.h"
+#include "include/oslogin_utils.h"
 
 using oslogin_utils::AuthOptions;
 using oslogin_utils::ContinueSession;


### PR DESCRIPTION
This change applies the rule in https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes which states that angle brackets should only be used where necessary (i.e. for system libs), and quotes should be heavily preferred. Furthermore, all include paths should be relative to the "source root," in this case `/src/`.