### PR TITLE
Fix a bug where very large GIDs would cause integer overflow errors

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ NSS_CACHE_OSLOGIN        = libnss_cache_oslogin-$(VERSION).so
 PAM_ADMIN                = pam_oslogin_admin.so
 PAM_LOGIN                = pam_oslogin_login.so
 
-BINARIES = google_oslogin_nss_cache google_authorized_keys google_authorized_keys_sk google_authorized_principals
+BINARIES = google_oslogin_nss_cache google_authorized_keys google_authorized_keys_sk google_authorized_principals oslogin_sshca
 
 .PHONY: all clean install
 .DEFAULT_GOAL := all

--- a/src/include/oslogin_utils.h
+++ b/src/include/oslogin_utils.h
@@ -229,7 +229,7 @@ bool ParseJsonToUsers(const string& json, std::vector<string>* users);
 bool GetGroupByName(string name, struct group* grp, BufferManager* buf, int* errnop);
 
 // Gets group matching GID.
-bool GetGroupByGID(int gid, struct group* grp, BufferManager* buf, int* errnop);
+bool GetGroupByGID(uint32_t gid, struct group* grp, BufferManager* buf, int* errnop);
 
 // Iterates through all users for a group, storing results in a provided string vector.
 bool GetUsersForGroup(string groupname, std::vector<string>* users, int* errnop);

--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -607,7 +607,10 @@ bool ParseJsonToGroups(const string& json, std::vector<Group>* result) {
     }
 
     Group g;
-    g.gid = json_object_get_int64(gid);
+    // We use json_object_get_int64 because GIDs are unsigned and may use all
+    // 32 bits, but there is no json_object_get_uint32.
+    // Because the GID should never exceed 32 bits, truncation is safe.
+    g.gid = (uint32_t)json_object_get_int64(gid);
 
     // get_int64 will confusingly return 0 if the string can't be converted to
     // an integer. We can't rely on type check as it may be a string in the API.
@@ -1120,7 +1123,7 @@ bool GetGroupByName(string name, struct group* result, BufferManager* buf, int* 
   return true;
 }
 
-bool GetGroupByGID(int gid, struct group* result, BufferManager* buf, int* errnop) {
+bool GetGroupByGID(uint32_t gid, struct group* result, BufferManager* buf, int* errnop) {
   std::stringstream url;
   std::vector<Group> groups;
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,7 +7,7 @@ endif
 TEST_RUNNER = ./test_runner --gtest_output=xml
 NEW_TEST_RUNNER = ./new_test_runner --gtest_output=xml
 SSHCA_TEST_RUNNER = ./sshca_runner --gtest_output=xml --gtest_filter="SSHCATests.*"
-CPPFLAGS += -I$(TOPDIR)/src/include -I$(TOPDIR)/third_party/include -I/usr/include/json-c -I$(GTEST_DIR) -isystem $(GTEST_DIR)/include
+CPPFLAGS += -I$(TOPDIR)/src/include -I/usr/include/json-c -I$(GTEST_DIR) -isystem $(GTEST_DIR)/include
 CXXFLAGS += -g -Wall -Wextra
 LDLIBS = -lcurl -ljson-c -lpthread
 

--- a/test/oslogin_sshca_test.cc
+++ b/test/oslogin_sshca_test.cc
@@ -14,10 +14,11 @@
 
 #include <errno.h>
 #include <gtest/gtest.h>
-#include <oslogin_sshca.h>
-#include <oslogin_utils.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include "oslogin_sshca.h"
+#include "oslogin_utils.h"
 
 using std::string;
 using std::vector;

--- a/test/oslogin_test.cc
+++ b/test/oslogin_test.cc
@@ -15,10 +15,11 @@
 // Requires libgtest-dev and gtest compiled and installed.
 #include <errno.h>
 #include <gtest/gtest.h>
-#include "../src/nss/new_nss_oslogin.c" // yes, the c file.
 #include <nss.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include "../src/nss/new_nss_oslogin.c" // yes, the c file.
 
 TEST(ParserTest, TestParsepasswd) {
   int res;

--- a/test/oslogin_utils_test.cc
+++ b/test/oslogin_utils_test.cc
@@ -15,9 +15,10 @@
 // Requires libgtest-dev and gtest compiled and installed.
 #include <errno.h>
 #include <gtest/gtest.h>
-#include <oslogin_utils.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#include "oslogin_utils.h"
 
 using std::string;
 using std::vector;
@@ -457,7 +458,7 @@ TEST(GetGroupByTest, GetGroupByGIDSucceeds) {
   int errnop = 0;
 
   struct group grp = {};
-  ASSERT_TRUE(GetGroupByGID(123452, &grp, &buf, &errnop));
+  ASSERT_TRUE(GetGroupByGID((uint32_t)123452, &grp, &buf, &errnop));
   ASSERT_EQ(errnop, 0);
 }
 

--- a/test/oslogin_utils_test.cc
+++ b/test/oslogin_utils_test.cc
@@ -360,6 +360,7 @@ TEST(ParseJsonToGroupsTest, ParseJsonToGroupsSucceedsWithHighGid) {
   std::vector<Group> groups;
   ASSERT_TRUE(ParseJsonToGroups(test_group, &groups));
   ASSERT_EQ(groups[0].gid, 4294967295);
+  ASSERT_GT(groups[0].gid, 0);
   ASSERT_EQ(groups[0].name, "demo");
 }
 


### PR DESCRIPTION
This PR fixes a typing bug where GIDs were being handled as signed 32-bit integers, which would make GIDs exceeding 2^31 incorrectly be printed as negative numbers. It includes a comment explaining why we parse integers as 64-bit (signed) ints using the JSON library, too (spoiler: because the JSON library has no unsigned versions of its functions).

This PR also includes a small improvement to the Makefile, since I noticed that `make clean` was skipping a binary file.