### PR TITLE
Fix bad struct initialization pattern `= { 0 }`

### DIFF
--- a/src/authorized_keys/authorized_keys.cc
+++ b/src/authorized_keys/authorized_keys.cc
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
     goto fail;
   }
 
-  sig = { 0 };
+  sig = {};
   sig.sa_handler = signal_handler;
   sigemptyset(&sig.sa_mask);
 

--- a/src/authorized_keys/authorized_keys.cc
+++ b/src/authorized_keys/authorized_keys.cc
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
   }
 
   user_name = argv[1];
-  opts = { 0 };
+  opts = {};
 
   if (AuthorizeUser(user_name, opts, &user_response)) {
     // At this point, we've verified the user can log in. Grab the ssh keys from

--- a/src/authorized_keys/authorized_keys_sk.cc
+++ b/src/authorized_keys/authorized_keys_sk.cc
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]) {
     goto fail;
   }
 
-  sig = { 0 };
+  sig = {};
   sig.sa_handler = signal_handler;
   sigemptyset(&sig.sa_mask);
 

--- a/src/authorized_keys/authorized_keys_sk.cc
+++ b/src/authorized_keys/authorized_keys_sk.cc
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
   user_name = argv[1];
   is_sa = (strncmp(user_name, "sa_", 3) == 0);
 
-  opts = { 0 };
+  opts = {};
   opts.security_key = true;
 
   if (AuthorizeUser(user_name, opts, &user_response)) {

--- a/src/authorized_principals/authorized_principals.cc
+++ b/src/authorized_principals/authorized_principals.cc
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
   const char *progname = FileName(argv[0]);
 
   fp_len = 0;
-  opts = { 0 };
+  opts = {};
   user_name = cert = fingerprint = NULL;
 
   SetupSysLog(SYSLOG_IDENT, progname);

--- a/src/authorized_principals/authorized_principals.cc
+++ b/src/authorized_principals/authorized_principals.cc
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
     goto fail;
   }
 
-  sig = { 0 };
+  sig = {};
   sig.sa_handler = signal_handler;
   sigemptyset(&sig.sa_mask);
 

--- a/src/pam/pam_oslogin_admin.cc
+++ b/src/pam/pam_oslogin_admin.cc
@@ -40,7 +40,7 @@ pam_sm_acct_mgmt(pam_handle_t* pamh, int flags, int argc, const char** argv) {
     return PAM_PERM_DENIED;
   }
 
-  opts = { 0 };
+  opts = {};
   opts.admin_policy_required = true;
 
   if (!AuthorizeUser(user_name, opts, &user_response)) {

--- a/src/pam/pam_oslogin_login.cc
+++ b/src/pam/pam_oslogin_login.cc
@@ -50,7 +50,7 @@ pam_sm_acct_mgmt(pam_handle_t* pamh, int flags, int argc, const char** argv) {
     return PAM_PERM_DENIED;
   }
 
-  opts = { 0 };
+  opts = {};
 
   if (!AuthorizeUser(user_name, opts, &user_response)) {
     return PAM_PERM_DENIED;


### PR DESCRIPTION
This initialization style, borrowed from C99, only performs as expected for *arrays*. For structs, it only initializes the struct's first member to zero, and it leaves the rest alone (unexpectedly!).

Personally, I prefer code to be written in such a way that empty initialization is never necessary (I disagree with the practice of always zero-initializing "just in case" -- you should always _know_ whether you're accessing a variable before it was initialized), but I digress... this incremental improvement will at least fix one more clang error while leaving the code largely as-is.