### PR TITLE
Fix base64.h's missing includes and BSD types

### DIFF
--- a/src/openbsd-compat/base64.h
+++ b/src/openbsd-compat/base64.h
@@ -118,10 +118,15 @@ static char Pad64 = '=';
 	   characters followed by one "=" padding character.
    */
 
+#include <string.h>
+#include <ctype.h>
+#include <stdint.h>
+#include <stddef.h>
+
 int
-b64_pton(char const *src, u_char *target, size_t targsize)
+b64_pton(char const *src, uint8_t *target, size_t targsize)
 {
-	u_int tarindex, state;
+	unsigned int tarindex, state;
 	int ch;
 	char *pos;
 

--- a/src/openbsd-compat/base64.h
+++ b/src/openbsd-compat/base64.h
@@ -210,6 +210,7 @@ b64_pton(char const *src, uint8_t *target, size_t targsize)
 			ch = *src++;		/* Skip the = */
 			/* Fall through to "single trailing =" case. */
 			/* FALLTHROUGH */
+                        [[fallthrough]];
 
 		case 3:		/* Valid, means two bytes of info */
 			/*


### PR DESCRIPTION
`base64.h` had a whole bunch of missing symbols if you tried to build it on its own: no includes, just vibes. 🦄

Since it was borrowed from BSD originally, it also had a few BSD-specific type aliases (e.g. `u_char`) that I'm frankly amazed `g++` didn't complain about. I've replaced these with standard type names or aliases, and added the libraries that contain the functions used here, like `string.h`'s `isspace(char*)` utility.

Finally, this CL also adds the style of fallthrough annotation statement that `clang` expects, with the `[[double braces]]`.