### PR TITLE
Apply "include what you use," fixing missing include statements broadly.

### DIFF
--- a/src/authorized_keys/authorized_keys.cc
+++ b/src/authorized_keys/authorized_keys.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include <iostream>
+#include <vector>
 
 #include <signal.h>
 

--- a/src/authorized_keys/authorized_keys_sk.cc
+++ b/src/authorized_keys/authorized_keys_sk.cc
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <vector>
 
 #include <signal.h>
 

--- a/src/authorized_principals/authorized_principals.cc
+++ b/src/authorized_principals/authorized_principals.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
 #include <iostream>
 
 #include <signal.h>

--- a/src/cache_refresh/cache_refresh.cc
+++ b/src/cache_refresh/cache_refresh.cc
@@ -21,9 +21,13 @@
 #include <syslog.h>
 #include <string.h>
 #include <unistd.h>
-#include <sstream>
 
+#include <cstdint>
+#include <cstdio>
 #include <fstream>
+#include <ios>
+#include <string>
+#include <vector>
 
 #include "include/compat.h"
 #include "include/oslogin_utils.h"

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -53,7 +53,7 @@ nss_module_register (const char *name, unsigned int *size,      \
 
 #else /* __FreeBSD__ */
 
-#include <security/pam_ext.h>
+#include <security/pam_ext.h>  // IWYU pragma: keep
 
 #define OSLOGIN_PASSWD_CACHE_PATH "/etc/oslogin_passwd.cache"
 #define OSLOGIN_GROUP_CACHE_PATH "/etc/oslogin_group.cache"

--- a/src/include/nss_cache_oslogin.h
+++ b/src/include/nss_cache_oslogin.h
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <errno.h>
 #include <grp.h>
 #include <nss.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <syslog.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/src/nss/nss_cache_oslogin.c
+++ b/src/nss/nss_cache_oslogin.c
@@ -14,15 +14,18 @@
 
 // An NSS module which adds supports for file /etc/oslogin_passwd.cache
 
+#include <errno.h>
 #include <nss.h>
-#include "include/nss_cache_oslogin.h"
-#include "include/compat.h"
-
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <time.h>
 
+#include "include/nss_cache_oslogin.h"
+#include "include/compat.h"
+
 // Locking implementation: use pthreads.
-#include <pthread.h>
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 #define NSS_CACHE_OSLOGIN_LOCK() \
   do {                           \

--- a/src/nss/nss_oslogin.cc
+++ b/src/nss/nss_oslogin.cc
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "include/compat.h"
-#include "include/oslogin_utils.h"
-
-#include <curl/curl.h>
 #include <errno.h>
 #include <grp.h>
 #include <nss.h>
@@ -27,9 +23,14 @@
 #include <unistd.h>
 #include <stdlib.h>
 
+#include <cstdio>
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
+
+#include "include/compat.h"
+#include "include/oslogin_utils.h"
 
 #define MAXBUFSIZE 32768
 

--- a/src/oslogin_sshca.cc
+++ b/src/oslogin_sshca.cc
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
+#include <cstring>
+
 #include "include/oslogin_sshca.h"
 #include "include/oslogin_utils.h"
 #include "openbsd-compat/base64.h"

--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -14,9 +14,13 @@
 
 // Requires libcurl4-openssl-dev, libjson-c5, and libjson-c-dev
 #include <curl/curl.h>
+#include <curl/easy.h>
 #include <errno.h>
 #include <grp.h>
 #include <json.h>
+#include <json_tokener.h>
+#include <json_types.h>
+#include <json_object.h>
 #include <nss.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,13 +28,14 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#include <cstdint>
 #include <cstring>
 #include <cstdarg>
 #include <iostream>
 #include <sstream>
 #include <fstream>
-
-#include <json_object.h>
+#include <string>
+#include <vector>
 
 #if defined(__clang__) || __GNUC__ > 4 || \
     (__GNUC__ == 4 &&                     \

--- a/src/pam/pam_oslogin_admin.cc
+++ b/src/pam/pam_oslogin_admin.cc
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 #include <security/pam_modules.h>
+#include <security/_pam_types.h>
+
+#include <cstddef>
+#include <cstdio>
+#include <string>
 
 #include "include/compat.h"
 #include "include/oslogin_utils.h"

--- a/src/pam/pam_oslogin_login.cc
+++ b/src/pam/pam_oslogin_login.cc
@@ -13,11 +13,18 @@
 // limitations under the License.
 
 #define PAM_SM_ACCOUNT
+
+#include <security/pam_ext.h>
 #include <security/pam_modules.h>
+#include <security/_pam_types.h>
 #include <syslog.h>
 
-#include <sstream>
+#include <cstddef>
+#include <cstdio>
 #include <map>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "include/compat.h"
 #include "include/oslogin_utils.h"


### PR DESCRIPTION
Proper discipline with `#include` statements makes refactoring much easier in the future, and makes code-tracing much easier. 