### PR TITLE
Fix json include

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ NSS_CACHE_OSLOGIN        = libnss_cache_oslogin-$(VERSION).so
 PAM_ADMIN                = pam_oslogin_admin.so
 PAM_LOGIN                = pam_oslogin_login.so
 
-BINARIES = google_oslogin_nss_cache google_authorized_keys google_authorized_keys_sk google_authorized_principals oslogin_sshca
+BINARIES = google_oslogin_nss_cache google_authorized_keys google_authorized_keys_sk google_authorized_principals
 
 .PHONY: all clean install
 .DEFAULT_GOAL := all

--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -18,9 +18,6 @@
 #include <errno.h>
 #include <grp.h>
 #include <json.h>
-#include <json_tokener.h>
-#include <json_types.h>
-#include <json_object.h>
 #include <nss.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
We want to have the opaque include in the case of json lib headers,
we've seen a shift of these header over the years by hiding them
behind json.h allows us to not have to handle backward compatibility
include strategies - being able to build for older systems such as
el8.