### PR TITLE
Send the correct type to SysLogErr to make the clang sanitizer happy.

### DIFF
--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -206,7 +206,7 @@ json_object* ParseJsonRoot(const string& json) {
     enum json_tokener_error jerr = json_tokener_get_error(tok);
     string error_message = json_tokener_error_desc(jerr);
     SysLogErr("Failed to parse root JSON element: \"%s\", from input \"%s\"",
-              error_message, json);
+              error_message.c_str(), json.c_str());
   }
 
   json_tokener_free(tok);


### PR DESCRIPTION
This type mismatch led to the weirdest, most opaque trap errors from the clang sanitizer. I actually wasn't able to even get clang to point this problem out to me directly, but thanks to a disassembler and some help from another expert, I was able to fix the issue.