### PR TITLE
Fix issue #160 by making the NSS cache module as stateless as possible.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@
 google_authorized_keys
 google_authorized_keys_sk
 google_oslogin_nss_cache
-test/sshca_runner
-test/test_detail.xml
 selinux/oslogin.mod
 selinux/oslogin.pp
 test/new_test_runner
+test/nss_runner
+test/sshca_runner
+test/test_detail.xml
 test/test_runner
 src/google_authorized_principals
 src/oslogin_sshca

--- a/src/nss/nss_cache_oslogin.c
+++ b/src/nss/nss_cache_oslogin.c
@@ -254,13 +254,19 @@ _nss_cache_oslogin_getgrgid_r(gid_t gid, struct group *result,
     char userbuf[userbuflen];
     if (_nss_cache_oslogin_getpwuid_r(gid, &user, userbuf, userbuflen, errnop) == NSS_STATUS_SUCCESS && user.pw_gid == user.pw_uid) {
         result->gr_gid = user.pw_gid;
+
+        // store "x" for password.
         char* string = buffer;
         strncpy(string, "x", 2);
         result->gr_passwd = string;
+
+        // store name.
         string = (char *)((size_t) string + 2);
         size_t name_len = strlen(user.pw_name)+1;
         strncpy(string, user.pw_name, name_len);
         result->gr_name = string;
+
+        // member array starts past strings.
         char **strarray = (char **)((size_t) string + name_len);
         strarray[0] = string;
         strarray[1] = NULL;
@@ -306,13 +312,19 @@ _nss_cache_oslogin_getgrnam_r(const char *name, struct group *result,
     char userbuf[userbuflen];
     if (_nss_cache_oslogin_getpwnam_r(name, &user, userbuf, userbuflen, errnop) == NSS_STATUS_SUCCESS && user.pw_gid == user.pw_uid) {
         result->gr_gid = user.pw_gid;
+
+        // store "x" for password.
         char* string = buffer;
         strncpy(string, "x", 2);
         result->gr_passwd = string;
+
+        // store name.
         string = (char *)((size_t) string + 2);
         size_t name_len = strlen(user.pw_name)+1;
         strncpy(string, user.pw_name, name_len);
         result->gr_name = string;
+
+        // member array starts past strings.
         char **strarray = (char **)((size_t) string + name_len);
         strarray[0] = string;
         strarray[1] = NULL;

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,11 +1,12 @@
 TOPDIR = $(realpath ..)
 
 ifeq ($(GTEST_DIR),)
-GTEST_DIR = /usr/src/googletest/googletest/
+GTEST_DIR = /usr/src/googletest/googletest
 endif
 
 TEST_RUNNER = ./test_runner --gtest_output=xml
 SSHCA_TEST_RUNNER = ./sshca_runner --gtest_output=xml --gtest_filter="SSHCATests.*"
+NSS_TEST_RUNNER = ./nss_runner --gtest_output=xml
 CPPFLAGS += -I$(TOPDIR)/src/include -I/usr/include/json-c -I$(GTEST_DIR) -isystem $(GTEST_DIR)/include
 CXXFLAGS += -g -Wall -Wextra
 LDLIBS = -lcurl -ljson-c -lpthread
@@ -28,6 +29,17 @@ test_runner: oslogin_utils_test.o $(TOPDIR)/src/oslogin_utils.o gtest-all.o
 sshca_runner: oslogin_sshca_test.o $(TOPDIR)/src/oslogin_utils.o $(TOPDIR)/src/oslogin_sshca.o gtest-all.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
+# nss_cache_oslogin.o has some different includes than other files,
+# so this extra rule tells Make how to build it properly.
+nss_cache_oslogin.o:
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -I$(TOPDIR)/src -c $(TOPDIR)/src/nss/nss_cache_oslogin.c -o $@ $(LDLIBS)
+
+oslogin_nss_cache_test.o: oslogin_nss_cache_test.cc
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -I$(TOPDIR)/src -I$(TOPDIR)/src/nss -c $^ -o $@ $(LDLIBS)
+
+nss_runner: oslogin_nss_cache_test.o nss_cache_oslogin.o gtest-all.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
+
 sshca_tests: sshca_runner
 	$(SSHCA_TEST_RUNNER)
 
@@ -36,6 +48,9 @@ non_network_tests: test_runner
 
 network_tests: test_runner ping reset
 	$(TEST_RUNNER) --gtest_filter=GetGroupByTest.*:GetUsersForGroupTest.*
+
+nss_tests: nss_runner
+	$(NSS_TEST_RUNNER)
 
 # run as $ make tests GTESTARGS="--gtest_filter=GetGroupByTest.*"
 alltests: test_runner

--- a/test/oslogin_nss_cache_test.cc
+++ b/test/oslogin_nss_cache_test.cc
@@ -1,0 +1,136 @@
+#include <gtest/gtest.h>
+#include <stdio.h>
+#include <pwd.h>
+#include <grp.h>
+#include <thread>
+
+// The C code to be tested needs to be included this way
+extern "C" {
+#include "nss_cache_oslogin.c"
+#include "include/compat.h"
+}
+
+class NssCacheTest : public ::testing::Test {
+protected:
+    // Create mock passwd and group files for tests
+    void SetUp() override {
+        FILE* p_file = fopen(OSLOGIN_PASSWD_CACHE_PATH, "w");
+        if (p_file == NULL) {
+          perror("Failed to open passwd cache file");
+        }
+        ASSERT_NE(p_file, nullptr);
+        fprintf(p_file, "testuser:x:1001:1001:Test User:/home/testuser:/bin/bash\n");
+        fprintf(p_file, "another:x:1002:1003:Another User:/home/another:/bin/sh\n");
+        // User with matching UID/GID for UPG tests
+        fprintf(p_file, "upguser:x:1004:1004:UPG User:/home/upguser:/bin/bash\n");
+        fclose(p_file);
+
+        FILE* g_file = fopen(OSLOGIN_GROUP_CACHE_PATH, "w");
+        if (g_file == NULL) {
+          perror("Failed to open group cache file");
+        }
+        ASSERT_NE(g_file, nullptr);
+        fprintf(g_file, "testgroup:x:2001:testuser\n");
+        fprintf(g_file, "anothergroup:x:1003:\n");
+        fclose(g_file);
+    }
+
+    // Clean up the mock files
+    void TearDown() override {
+        remove(OSLOGIN_PASSWD_CACHE_PATH);
+        remove(OSLOGIN_GROUP_CACHE_PATH);
+    }
+
+    // Helper to allocate buffer for NSS functions
+    static constexpr size_t BUFLEN = 4096;
+    char buffer[BUFLEN];
+    int errnop;
+};
+
+TEST_F(NssCacheTest, GetPwUidSuccess) {
+    struct passwd result;
+    enum nss_status status = _nss_cache_oslogin_getpwuid_r(1001, &result, buffer, BUFLEN, &errnop);
+    ASSERT_EQ(status, NSS_STATUS_SUCCESS);
+    ASSERT_STREQ(result.pw_name, "testuser");
+    ASSERT_EQ(result.pw_uid, 1001);
+    ASSERT_EQ(result.pw_gid, 1001);
+}
+
+TEST_F(NssCacheTest, GetPwUidNotFound) {
+    struct passwd result;
+    enum nss_status status = _nss_cache_oslogin_getpwuid_r(9999, &result, buffer, BUFLEN, &errnop);
+    ASSERT_EQ(status, NSS_STATUS_NOTFOUND);
+}
+
+TEST_F(NssCacheTest, GetGrGidForUPG) {
+    struct group result;
+    // For a UPG, getgrgid should succeed by finding the user in the passwd cache.
+    //
+    enum nss_status status = _nss_cache_oslogin_getgrgid_r(1004, &result, buffer, BUFLEN, &errnop);
+    ASSERT_EQ(status, NSS_STATUS_SUCCESS);
+    ASSERT_STREQ(result.gr_name, "upguser");
+    ASSERT_EQ(result.gr_gid, 1004);
+}
+
+TEST_F(NssCacheTest, BufferTooSmall) {
+    struct passwd result;
+    char small_buffer[5];
+    enum nss_status status = _nss_cache_oslogin_getpwnam_r("testuser", &result, small_buffer, sizeof(small_buffer), &errnop);
+    // The function should report that the buffer is too small.
+    //
+    ASSERT_EQ(status, NSS_STATUS_TRYAGAIN);
+    ASSERT_EQ(errnop, ERANGE);
+}
+
+TEST_F(NssCacheTest, EnumerateAllUsers) {
+    struct passwd result;
+    std::vector<std::string> users;
+
+    _nss_cache_oslogin_setpwent(0);
+    while (_nss_cache_oslogin_getpwent_r(&result, buffer, BUFLEN, &errnop) == NSS_STATUS_SUCCESS) {
+        users.push_back(result.pw_name);
+    }
+    _nss_cache_oslogin_endpwent();
+
+    ASSERT_EQ(users.size(), 3);
+    ASSERT_EQ(users[0], "testuser");
+    ASSERT_EQ(users[1], "another");
+    ASSERT_EQ(users[2], "upguser");
+}
+
+/** A regression test for issue #160. */
+TEST_F(NssCacheTest, InterleavedLookupDoesNotCorruptEnumerationState) {
+    struct passwd pwent_result;
+    struct passwd pwnam_result;
+    char pwent_buffer[BUFLEN];
+    char pwnam_buffer[BUFLEN];
+    int errnop;
+
+    // 1. Start the user enumeration process. This opens the passwd cache file
+    //    and positions the cursor at the beginning.
+    ASSERT_EQ(_nss_cache_oslogin_setpwent(0), NSS_STATUS_SUCCESS);
+
+    // 2. Read the first entry ("testuser") from the enumeration.
+    //    This advances the cursor to the second line.
+    ASSERT_EQ(_nss_cache_oslogin_getpwent_r(&pwent_result, pwent_buffer, BUFLEN, &errnop), NSS_STATUS_SUCCESS);
+    ASSERT_STREQ(pwent_result.pw_name, "testuser");
+
+    // 3. Perform a lookup for a different user ("another"). In the old, buggy code,
+    //    this call would reset the enumeration's file pointer back to the beginning.
+    ASSERT_EQ(_nss_cache_oslogin_getpwnam_r("another", &pwnam_result, pwnam_buffer, BUFLEN, &errnop), NSS_STATUS_SUCCESS);
+    ASSERT_STREQ(pwnam_result.pw_name, "another");
+
+    // 4. Continue the enumeration. With the fix, the thread-local file pointer
+    //    should be unaffected, and this call should read the *second* entry.
+    //    If the bug still existed, this would incorrectly read the first entry again.
+    ASSERT_EQ(_nss_cache_oslogin_getpwent_r(&pwent_result, pwent_buffer, BUFLEN, &errnop), NSS_STATUS_SUCCESS);
+    ASSERT_STREQ(pwent_result.pw_name, "another"); // Verify we got the second user.
+
+    // 5. Clean up the enumeration state.
+    _nss_cache_oslogin_endpwent();
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/oslogin_nss_cache_test.cc
+++ b/test/oslogin_nss_cache_test.cc
@@ -12,7 +12,16 @@ extern "C" {
 
 class NssCacheTest : public ::testing::Test {
 protected:
-    // Create mock passwd and group files for tests
+    /* Create mock passwd and group files for tests.
+     *
+     * Note that using the hardcoded OSLOGIN_*_CACHE_PATH macros may cause file
+     * permission issues, requiring us to run as root. Running these tests will
+     * also wipe the OS Login cache (in case you're testing this on a GCE VM),
+     * which should be largely harmless but is nonetheless a side-effect to be
+     * aware of.
+     *
+     * If this proves to be a problem, then consider adding in a few functions
+     * to nss_cache_oslogin.c to allow the cache paths to be overridden. */
     void SetUp() override {
         FILE* p_file = fopen(OSLOGIN_PASSWD_CACHE_PATH, "w");
         if (p_file == NULL) {
@@ -21,7 +30,7 @@ protected:
         ASSERT_NE(p_file, nullptr);
         fprintf(p_file, "testuser:x:1001:1001:Test User:/home/testuser:/bin/bash\n");
         fprintf(p_file, "another:x:1002:1003:Another User:/home/another:/bin/sh\n");
-        // User with matching UID/GID for UPG tests
+        // User with matching UID/GID for UPG tests.
         fprintf(p_file, "upguser:x:1004:1004:UPG User:/home/upguser:/bin/bash\n");
         fclose(p_file);
 
@@ -35,13 +44,13 @@ protected:
         fclose(g_file);
     }
 
-    // Clean up the mock files
+    // Clean up the mock files.
     void TearDown() override {
         remove(OSLOGIN_PASSWD_CACHE_PATH);
         remove(OSLOGIN_GROUP_CACHE_PATH);
     }
 
-    // Helper to allocate buffer for NSS functions
+    // Helper to allocate buffer for NSS functions.
     static constexpr size_t BUFLEN = 4096;
     char buffer[BUFLEN];
     int errnop;


### PR DESCRIPTION
Issue #160 was caused by a shared file pointer being inappropriately changed by different NSS functions. This change not only changes the file pointer to be thread-local, but also makes individual functions more responsible for the file pointer's full lifecycle. This change also includes a regression test for issue #160.

Along the way, this change also fixes another bug I noticed: the old NSS cache module registered the groups-related functions in the wrong database! This would probably result in requests about groups that did not match a UID (i.e. any group that was not a "user-private group," in POSIX parlance) failing unexpectedly, causing NSS to fall back to the network (non-cache) OS Login module, thereby generating extra RPCs to the OS Login Groups API. We're retiring the OS Login Groups API very soon anyway, and so UPGs will soon be the only kind of OS Login group (for the most part, anyway), but still: it's a bug to be fixed. ;)