### PR TITLE
extract the principal from certs when cloud_run enabled

### DIFF
--- a/src/authorized_principals/authorized_principals.cc
+++ b/src/authorized_principals/authorized_principals.cc
@@ -42,7 +42,7 @@ void signal_handler(int signo) {
 
 int main(int argc, char* argv[]) {
   size_t fp_len;
-  char *user_name, *cert, *fingerprint;
+  char *user_name, *cert, *fingerprint, *principal;
   struct sigaction sig;
   struct AuthOptions opts;
   string user_response;
@@ -81,7 +81,7 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  fp_len = FingerPrintFromBlob(cert, &fingerprint);
+  fp_len = FingerPrintFromBlob(cert, &fingerprint, &principal);
   if (fp_len == 0) {
     SysLogErr("Could not extract/parse fingerprint from certificate.");
     goto fail;
@@ -89,6 +89,10 @@ int main(int argc, char* argv[]) {
 
   opts.fingerprint = fingerprint;
   opts.fp_len = fp_len;
+
+  if (cloud_run) {
+    user_name = principal;
+  }
 
   if (AuthorizeUser(user_name, opts, &user_response, cloud_run)) {
     cout << user_name << endl;

--- a/src/include/oslogin_sshca.h
+++ b/src/include/oslogin_sshca.h
@@ -15,7 +15,7 @@
 #ifndef _OSLOGIN_SSHCA_H_
 #define _OSLOGIN_SSHCA_H_ 1
 
-#include "include/compat.h"
+#include "compat.h"
 #include <ctype.h>
 #include <security/pam_modules.h>
 #include <stdlib.h>
@@ -44,7 +44,7 @@
 namespace oslogin_sshca {
 // The public interface - given a blob with a list of certificates we parse each of
 // them until we find the first fingerprint.
-int FingerPrintFromBlob(const char *blob, char **fingerprint);
+int FingerPrintFromBlob(const char *blob, char **fingerprint, char **principal);
 }
 
 #endif

--- a/test/oslogin_sshca_test.cc
+++ b/test/oslogin_sshca_test.cc
@@ -346,49 +346,57 @@ using oslogin_sshca::FingerPrintFromBlob;
 TEST(SSHCATests, TestValidSingleExtCert) {
   struct {
     const char *key;
+    const char *principal;
   } *iter, tests[] = {
-    {VALID_RSA_SINGLE_EXT},
-    {VALID_RSA_MULTI_EXT},
-    {VALID_RSA_MULTI_EQUAL_EXT},
-    {VALID_DSA_SINGLE_EXT},
-    {VALID_DSA_MULTI_EXT},
-    {VALID_ECDSA_SINGLE_EXT},
-    {VALID_ECDSA_MULTI_EXT},
-    {VALID_ED25519_SINGLE_EXT},
-    {VALID_ED25519_MULTI_EXT},
-    { NULL },
+    {VALID_RSA_SINGLE_EXT, "fingerprint@google.com"},
+    {VALID_RSA_MULTI_EXT, "fingerprint@google.com"},
+    {VALID_RSA_MULTI_EQUAL_EXT, "fakey"},
+    {VALID_DSA_SINGLE_EXT, "fingerprint@google.com"},
+    {VALID_DSA_MULTI_EXT, "fingerprint@google.com"},
+    {VALID_ECDSA_SINGLE_EXT, "pantheon.sitar.mig"},
+    {VALID_ECDSA_MULTI_EXT, "fingerprint@google.com"},
+    {VALID_ED25519_SINGLE_EXT, "fingerprint@google.com"},
+    {VALID_ED25519_MULTI_EXT, "fingerprint@google.com"},
+    { NULL, NULL,},
   };
 
   for (iter = tests; iter->key != NULL; iter++) {
-    char *fingerprint = NULL;
-    size_t len = FingerPrintFromBlob(iter->key, &fingerprint);
+    char *fingerprint, *principal;
+    fingerprint = principal = NULL;
+    size_t len = FingerPrintFromBlob(iter->key, &fingerprint, &principal);
     ASSERT_GT(len, 0);
     ASSERT_STREQ(fingerprint, "b86db4ca-09fd-429e-b121-a12799614032");
+    ASSERT_STREQ(principal, iter->principal);
     free(fingerprint);
+    free(principal);
   }
 }
 
 TEST(SSHCATests, TestInvalidNoFpCert) {
   struct {
     const char *key;
+    const char *principal;
   } *iter, tests[] = {
-    {INVALID_DSA_NO_FP},
-    {INVALID_DSA_NON_CERT},
-    {INVALID_ED25519_NO_FP},
-    {INVALID_ED25519_NON_CERT},
-    {INVALID_RSA_NO_FP},
-    {INVALID_RSA_NON_CERT},
-    {INVALID_ECDSA_NO_FP},
-    {INVALID_ECDSA_NON_CERT},
-    { NULL },
+    {INVALID_DSA_NO_FP, "fingerprint@google.com"},
+    {INVALID_DSA_NON_CERT, NULL},
+    {INVALID_ED25519_NO_FP, "fingerprint@google.com"},
+    {INVALID_ED25519_NON_CERT, NULL},
+    {INVALID_RSA_NO_FP, "fingerprint@google.com"},
+    {INVALID_RSA_NON_CERT, NULL},
+    {INVALID_ECDSA_NO_FP, "fingerprint@google.com"},
+    {INVALID_ECDSA_NON_CERT, NULL},
+    { NULL, NULL},
   };
 
   for (iter = tests; iter->key != NULL; iter++) {
-    char *fingerprint = NULL;
-    size_t len = FingerPrintFromBlob(iter->key, &fingerprint);
+    char *fingerprint, *principal;
+    fingerprint = principal = NULL;
+    size_t len = FingerPrintFromBlob(iter->key, &fingerprint, &principal);
     ASSERT_EQ(len, 0);
     ASSERT_STREQ(fingerprint, NULL);
+    ASSERT_STREQ(principal, iter->principal);
     free(fingerprint);
+    free(principal);
   }
 }
 


### PR DESCRIPTION
Always extract the principal from ssh certs.
When --cloud_run enabled, use principal as username for authentication.


Tested with `make sshcatests`
