### PR TITLE
Log the response body when an auth failure occurs.

### DIFF
--- a/src/oslogin_utils.cc
+++ b/src/oslogin_utils.cc
@@ -1304,7 +1304,8 @@ static bool ApplyPolicy(const char *user_name, string email, const char *policy,
 
   if (http_code != 200) {
     SysLogErr("Failed to validate that OS Login user %s has %s permission; "
-              "got HTTP response code: %lu", user_name, policy, http_code);
+              "got HTTP response code: %lu; got HTTP response body: %s",
+              user_name, policy, http_code, response);
     return false;
   }
 


### PR DESCRIPTION
The response body usually has a helpful error message in it, which we ought to include in server logs.