### PR TITLE
Implement a binary cache for OS Login passwd entries.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - ajorg
+  - anandadalton
   - bkatyl
   - chaitanyakulkarni28
   - dorileo

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/sh
 TOPDIR = $(realpath ..)
 
-CPPFLAGS += -I. -I/usr/include/json-c
+CPPFLAGS += -I. -Iinclude -I/usr/include/json-c
 FLAGS = -fPIC -Wall -g
 CFLAGS += $(FLAGS) -Wstrict-prototypes
 CXXFLAGS += $(FLAGS)
@@ -71,7 +71,7 @@ $(NSS_OSLOGIN): nss/nss_oslogin.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 $(NSS_CACHE_OSLOGIN): SONAME = $(NSS_CACHE_OSLOGIN_SONAME)
-$(NSS_CACHE_OSLOGIN): nss/nss_cache_oslogin.o nss/compat/getpwent_r.o oslogin_utils.o
+$(NSS_CACHE_OSLOGIN): nss/nss_cache_oslogin.o nss/compat/getpwent_r.o oslogin_utils.o nss/oslogin_passwd_cache_reader.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 # PAM modules
@@ -93,7 +93,7 @@ google_authorized_keys: authorized_keys/authorized_keys.o oslogin_utils.o
 google_authorized_keys_sk: authorized_keys/authorized_keys_sk.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
-google_oslogin_nss_cache: cache_refresh/cache_refresh.o oslogin_utils.o
+google_oslogin_nss_cache: cache_refresh/cache_refresh.o cache_refresh/oslogin_passwd_cache_writer.o oslogin_utils.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
 install: all

--- a/src/cache_refresh/oslogin_passwd_cache_writer.cc
+++ b/src/cache_refresh/oslogin_passwd_cache_writer.cc
@@ -1,0 +1,190 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <endian.h>
+#include <fstream>
+#include <ios>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "include/eytzinger_layout.h"
+#include "include/oslogin_index_structs.h"
+#include "include/oslogin_passwd_cache_writer.h"
+
+constexpr size_t kIndexNameRecordBaseSize =
+    sizeof(uint64_t) * 3 + sizeof(uint16_t);
+
+namespace {
+struct passwd_cache_header {
+  uint64_t uid_index_offset;
+  uint64_t uid_index_len;  // number of entries
+  uint64_t name_index_offset;
+  uint64_t name_index_len;  // number of entries
+  uint64_t text_offset;
+  uint64_t text_len;  // in bytes
+};
+constexpr size_t kHeaderSize = 6 * sizeof(uint64_t);
+
+void write_le64(std::ofstream& out, uint64_t data) {
+    uint64_t le_data = htole64(data);
+    out.write(reinterpret_cast<const char*>(&le_data), sizeof(le_data));
+}
+
+void write_le32(std::ofstream& out, uint32_t data) {
+    uint32_t le_data = htole32(data);
+    out.write(reinterpret_cast<const char*>(&le_data), sizeof(le_data));
+}
+
+void write_le16(std::ofstream& out, uint16_t data) {
+    uint16_t le_data = htole16(data);
+    out.write(reinterpret_cast<const char*>(&le_data), sizeof(le_data));
+}
+
+}  // namespace
+
+OsLoginPasswdCacheWriter::OsLoginPasswdCacheWriter() = default;
+
+OsLoginPasswdCacheWriter::~OsLoginPasswdCacheWriter() = default;
+
+void OsLoginPasswdCacheWriter::AddUser(const std::string& name,
+                                       const std::string& passwd,
+                                       uid_t uid,
+                                       gid_t gid,
+                                       const std::string& gecos,
+                                       const std::string& dir,
+                                       const std::string& shell) {
+  // 1. Format the text line
+  std::ostringstream line;
+  line << name << ":" << passwd << ":" << uid << ":" << gid << ":"
+       << gecos << ":" << dir << ":" << shell << "\n";
+  std::string line_str = line.str();
+
+  // 2. Calculate the "Relative Offset"
+  uint64_t relative_offset = (uint64_t)text_buffer_.tellp();
+
+  // 3. Buffer the text
+  text_buffer_ << line_str;
+
+  // 4. Create Index Entries (with RELATIVE offsets for now)
+  OsLoginIndexUID uid_entry {};
+  uid_entry.text_offset = relative_offset;  // Temporary!
+  uid_entry.uid = uid;
+  uid_index_.push_back(uid_entry);
+
+  OsLoginIndexName name_entry {};
+  name_entry.text_offset = relative_offset;  // Temporary!
+  name_entry.name_len = name.size();
+  name_entry.name = name;
+  name_index_.push_back(name_entry);
+}
+
+bool OsLoginPasswdCacheWriter::Commit(std::ofstream& out) {
+  // 1. Sort the in-memory indices.
+  std::sort(uid_index_.begin(), uid_index_.end());
+  std::sort(name_index_.begin(), name_index_.end());
+
+  // Convert to Eytzinger layout.
+  uid_index_ = to_eytzinger_layout(uid_index_);
+  name_index_ = to_eytzinger_layout(name_index_);
+
+  // For each name index entry, the size is kIndexNameRecordBaseSize + name_len.
+  // This means that the offset of each entry is equal to the sum of the sizes
+  // of all preceding entries. We can calculate the correct value for each entry
+  // by iterating through the sorted array and accumulating the size.
+  uint64_t name_index_offset = 0;
+  for (auto& entry : name_index_) {
+    entry.self_offset = name_index_offset;
+    name_index_offset += kIndexNameRecordBaseSize + entry.name_len;
+  }
+
+  for (size_t i = 0; i < name_index_.size(); ++i) {
+    size_t left_child_index = 2 * (i + 1) - 1;
+    size_t right_child_index = 2 * (i + 1);
+    if (left_child_index < name_index_.size()) {
+      name_index_[i].left_child_offset =
+          name_index_[left_child_index].self_offset;
+    }
+    if (right_child_index < name_index_.size()) {
+      name_index_[i].right_child_offset =
+          name_index_[right_child_index].self_offset;
+    }
+  }
+
+  // Now we know the correct offsets for everything. We can write to the file.
+  uint64_t uid_section_size =
+      uid_index_.size() * (sizeof(uint64_t) + sizeof(uint32_t));
+  uint64_t name_section_size = name_index_offset;  // Accumulated above
+
+  passwd_cache_header header;
+  header.uid_index_len = uid_index_.size();
+  header.name_index_len = name_index_.size();
+  header.uid_index_offset = kHeaderSize;
+  header.name_index_offset = header.uid_index_offset + uid_section_size;
+  header.text_offset = header.name_index_offset + name_section_size;
+  std::string text = text_buffer_.str();
+  header.text_len = text.length();
+
+  for (auto& entry : uid_index_) {
+    entry.text_offset += header.text_offset;
+  }
+  for (auto& entry : name_index_) {
+    entry.text_offset += header.text_offset;
+    if (entry.left_child_offset != 0) {
+      entry.left_child_offset += header.name_index_offset;
+    }
+    if (entry.right_child_offset != 0) {
+      entry.right_child_offset += header.name_index_offset;
+    }
+  }
+
+  if (!out) {
+    return false;
+  }
+
+  // Write header fields individually in little-endian to avoid padding issues
+  // and ensure endian compatibility for C99 interop.
+  write_le64(out, header.uid_index_offset);
+  write_le64(out, header.uid_index_len);
+  write_le64(out, header.name_index_offset);
+  write_le64(out, header.name_index_len);
+  write_le64(out, header.text_offset);
+  write_le64(out, header.text_len);
+
+  for (const auto& entry : uid_index_) {
+    write_le64(out, entry.text_offset);
+    write_le32(out, entry.uid);
+  }
+
+  for (const auto& entry : name_index_) {
+    write_le64(out, entry.text_offset);
+    write_le64(out, entry.left_child_offset);
+    write_le64(out, entry.right_child_offset);
+    write_le16(out, entry.name_len);
+    out.write(entry.name.c_str(), entry.name_len);
+  }
+
+  out.write(text.c_str(), text.length());
+
+  if (out.fail()) {
+    return false;
+  }
+  return true;
+}

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -38,14 +38,15 @@ nss_module_register (const char *name, unsigned int *size,      \
     return (methods);                                           \
 }
 
-#define OSLOGIN_PASSWD_CACHE_PATH "/usr/local/etc/oslogin_passwd.cache"
-#define OSLOGIN_GROUP_CACHE_PATH "/usr/local/etc/oslogin_group.cache"
 #define PASSWD_PATH "/usr/local/etc/passwd"
 
-#define K_DEFAULT_PFILE_PATH "/usr/local/etc/oslogin_passwd.cache"
+#define K_DEFAULT_PFILE_PATH "/usr/local/etc/oslogin_passwd.cache.bin"
 #define K_DEFAULT_BACKUP_PFILE_PATH "/usr/local/etc/oslogin_passwd.cache.bak"
 #define K_DEFAULT_GFILE_PATH "/usr/local/etc/oslogin_group.cache"
 #define K_DEFAULT_BACKUP_GFILE_PATH "/usr/local/etc/oslogin_group.cache.bak"
+#define OSLOGIN_PASSWD_CACHE_PATH "/usr/local/etc/oslogin_passwd.cache.bin"
+#define OSLOGIN_PASSWD_LEGACY_CACHE_PATH "/usr/local/etc/oslogin_passwd.cache"
+#define OSLOGIN_GROUP_CACHE_PATH "/usr/local/etc/oslogin_group.cache"
 
 #define PAM_SYSLOG(pamh, ...) syslog(__VA_ARGS__)
 #define DEFAULT_SHELL "/bin/sh"
@@ -55,14 +56,15 @@ nss_module_register (const char *name, unsigned int *size,      \
 
 #include <security/pam_ext.h>  // IWYU pragma: keep
 
-#define OSLOGIN_PASSWD_CACHE_PATH "/etc/oslogin_passwd.cache"
-#define OSLOGIN_GROUP_CACHE_PATH "/etc/oslogin_group.cache"
 #define PASSWD_PATH "/etc/passwd"
 
-#define K_DEFAULT_PFILE_PATH "/etc/oslogin_passwd.cache"
+#define K_DEFAULT_PFILE_PATH "/etc/oslogin_passwd.cache.bin"
 #define K_DEFAULT_BACKUP_PFILE_PATH "/etc/oslogin_passwd.cache.bak"
 #define K_DEFAULT_GFILE_PATH "/etc/oslogin_group.cache"
 #define K_DEFAULT_BACKUP_GFILE_PATH "/etc/oslogin_group.cache.bak"
+#define OSLOGIN_PASSWD_CACHE_PATH "/etc/oslogin_passwd.cache.bin"
+#define OSLOGIN_PASSWD_LEGACY_CACHE_PATH "/etc/oslogin_passwd.cache"
+#define OSLOGIN_GROUP_CACHE_PATH "/etc/oslogin_group.cache"
 
 #define PAM_SYSLOG pam_syslog
 #define DEFAULT_SHELL "/bin/bash"

--- a/src/include/eytzinger_layout.h
+++ b/src/include/eytzinger_layout.h
@@ -1,0 +1,54 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OSLOGIN_EYTZINGER_LAYOUT_H
+#define OSLOGIN_EYTZINGER_LAYOUT_H
+
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+// Function to convert a sorted vector to Eytzinger layout.
+// The input vector must be sorted.
+// Returns a new vector with elements arranged in Eytzinger layout.
+template <typename T>
+std::vector<T> to_eytzinger_layout(const std::vector<T>& sorted_input) {
+  if (sorted_input.empty()) {
+    return {};
+  }
+  std::vector<T> output(sorted_input.size());
+
+  std::function<void(size_t, size_t&)> eytzingerize =
+    [&](size_t eytzinger_idx, size_t& sorted_idx) {
+    if (eytzinger_idx - 1 < sorted_input.size()) {
+      // Traverse Left Child (2 * eytzinger_idx)
+      eytzingerize(2 * eytzinger_idx, sorted_idx);
+
+      // Visit Node: Place the next element from sorted_input
+      if (sorted_idx < sorted_input.size()) {
+        output[eytzinger_idx - 1] = sorted_input[sorted_idx++];
+      }
+
+      // Traverse Right Child (2 * eytzinger_idx + 1)
+      eytzingerize(2 * eytzinger_idx + 1, sorted_idx);
+    }
+  };
+
+  size_t sorted_idx = 0;
+  eytzingerize(1, sorted_idx);  // Start with Eytzinger index 1
+
+  return output;
+}
+
+#endif  // OSLOGIN_EYTZINGER_LAYOUT_H

--- a/src/include/oslogin_index_structs.h
+++ b/src/include/oslogin_index_structs.h
@@ -1,0 +1,48 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OSLOGIN_OSLOGIN_INDEX_STRUCTS_H
+#define OSLOGIN_OSLOGIN_INDEX_STRUCTS_H
+
+#include <sys/types.h>
+
+#include <cstdint>
+#include <string>
+
+struct OsLoginIndexUID {
+  uint64_t text_offset;
+  uid_t uid;
+
+  bool operator<(const OsLoginIndexUID& other) const {
+    return uid < other.uid;
+  }
+};
+
+struct OsLoginIndexName {
+  uint64_t left_child_offset;
+  uint64_t right_child_offset;
+  uint64_t text_offset;
+  uint16_t name_len;
+  std::string name;
+
+  // Only used in-memory and not written to disk. Used to store the relative
+  // offset of each entry in the name index during construction.
+  uint64_t self_offset;
+
+  bool operator<(const OsLoginIndexName& other) const {
+    return name < other.name;
+  }
+};
+
+#endif  // OSLOGIN_OSLOGIN_INDEX_STRUCTS_H

--- a/src/include/oslogin_passwd_cache_reader.h
+++ b/src/include/oslogin_passwd_cache_reader.h
@@ -1,0 +1,69 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OSLOGIN_PASSWD_CACHE_READER_H
+#define OSLOGIN_PASSWD_CACHE_READER_H
+
+#include <nss.h>
+#include <pwd.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+// We need this for the C++ tests.
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct PasswdCache PasswdCache;
+
+PasswdCache* open_passwd_cache(const char* filename);
+void close_passwd_cache(PasswdCache* cache);
+
+// NSS-style lookup functions.
+// Return NSS_STATUS_SUCCESS if found, NSS_STATUS_NOTFOUND if not found,
+// NSS_STATUS_TRYAGAIN if buffer too small (errnop=ERANGE) or parse error
+// (errnop=EINVAL).
+enum nss_status lookup_passwd_by_uid_r(PasswdCache* cache, uid_t uid,
+                                       struct passwd* result, char* buffer,
+                                       size_t buflen, int* errnop);
+enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
+                                        struct passwd* result, char* buffer,
+                                        size_t buflen, int* errnop);
+
+// State for iterating through passwd entries, for getpwent_r implementation.
+typedef struct {
+  // Internal state: offset of the next line to read in cache text section.
+  uint64_t internal_offset_;
+} PasswdCacheIter;
+
+// Initialize iterator state for setpwent.
+void passwd_cache_iter_begin(PasswdCache* cache, PasswdCacheIter* iter);
+
+// Get next entry for getpwent_r.
+// Reads entry and advances iterator.
+enum nss_status passwd_cache_iter_next_r(PasswdCache* cache,
+                                         PasswdCacheIter* iter,
+                                         struct passwd* result, char* buffer,
+                                         size_t buflen, int* errnop);
+
+// Functions to inspect cache header for testing.
+uint64_t get_passwd_cache_uid_count(PasswdCache* cache);
+uint64_t get_passwd_cache_name_count(PasswdCache* cache);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* OSLOGIN_PASSWD_CACHE_READER_H */

--- a/src/include/oslogin_passwd_cache_writer.h
+++ b/src/include/oslogin_passwd_cache_writer.h
@@ -1,0 +1,66 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OSLOGIN_OSLOGIN_PASSWD_CACHE_WRITER_H
+#define OSLOGIN_OSLOGIN_PASSWD_CACHE_WRITER_H
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "include/oslogin_index_structs.h"
+
+class OsLoginPasswdCacheWriter {
+ public:
+  // Constructor: Opens the temporary file for writing.
+  // The final filename is provided for the Commit() step,
+  // but the temporary file is used for all actual writing.
+  OsLoginPasswdCacheWriter();
+
+  // Destructor: Closes the file.
+  // Warning: If Commit() was not called, the file will be incomplete/invalid.
+  ~OsLoginPasswdCacheWriter();
+
+  // Adds a user entry to the cache.
+  // This writes the text line immediately and buffers the index entries in RAM.
+  void AddUser(const std::string& name,
+               const std::string& passwd,
+               uid_t uid,
+               gid_t gid,
+               const std::string& gecos,
+               const std::string& dir,
+               const std::string& shell);
+
+  // Finalizes the cache file.
+  // 1. Sorts the in-memory indices.
+  // 2. Writes a header with pointers to the index and text sections.
+  // 3. Writes the UID Index section.
+  // 4. Writes the Name Index section.
+  // 5. Writes the text lines.
+  // Returns true on success.
+  // The caller is responsible for opening and closing the ofstream.
+  bool Commit(std::ofstream& out);
+
+ private:
+  // In-memory buffer for the text lines (`passwd`-like format)
+  std::ostringstream text_buffer_;
+
+  // In-memory buffers for the indices
+  // We collect these as we add users, then sort them at Commit time.
+  std::vector<OsLoginIndexUID> uid_index_;
+  std::vector<OsLoginIndexName> name_index_;
+};
+
+#endif  // OSLOGIN_OSLOGIN_PASSWD_CACHE_WRITER_H

--- a/src/nss/oslogin_passwd_cache_reader.c
+++ b/src/nss/oslogin_passwd_cache_reader.c
@@ -1,0 +1,385 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <endian.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <nss.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "include/oslogin_passwd_cache_reader.h"
+
+// Eytzinger layout:
+// Parent of k is (k-1)/2
+// Left child of k is 2k+1
+// Right child of k is 2k+2
+
+struct passwd_cache_header {
+  uint64_t uid_index_offset;
+  uint64_t uid_index_len;
+  uint64_t name_index_offset;
+  uint64_t name_index_len;
+  uint64_t text_offset;
+  uint64_t text_len;
+};
+
+struct PasswdCache {
+  void* map;
+  size_t map_size;
+  struct passwd_cache_header header;
+};
+
+// Because the file is a binary format, we need special functions to read
+// multi-byte values from the file in the correct endianness.
+static uint16_t read_le16(const uint8_t* p) {
+  uint16_t val;
+  memcpy(&val, p, sizeof(val));
+  return le16toh(val);
+}
+
+static uint32_t read_le32(const uint8_t* p) {
+  uint32_t val;
+  memcpy(&val, p, sizeof(val));
+  return le32toh(val);
+}
+
+static uint64_t read_le64(const uint8_t* p) {
+  uint64_t val;
+  memcpy(&val, p, sizeof(val));
+  return le64toh(val);
+}
+
+PasswdCache* open_passwd_cache(const char* filename) {
+  int fd = open(filename, O_RDONLY);
+  if (fd == -1) {
+    return NULL;
+  }
+
+  struct stat st;
+  if (fstat(fd, &st) == -1) {
+    close(fd);
+    return NULL;
+  }
+
+  void* map = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
+  close(fd);
+  if (map == MAP_FAILED) {
+    return NULL;
+  }
+
+  PasswdCache* cache = (PasswdCache*)malloc(sizeof(PasswdCache));
+  if (!cache) {
+    munmap(map, st.st_size);
+    return NULL;
+  }
+
+  cache->map = map;
+  cache->map_size = st.st_size;
+
+  // Read header
+  uint8_t* p = (uint8_t*)map;
+  cache->header.uid_index_offset = read_le64(p);
+  cache->header.uid_index_len = read_le64(p + 8);
+  cache->header.name_index_offset = read_le64(p + 16);
+  cache->header.name_index_len = read_le64(p + 24);
+  cache->header.text_offset = read_le64(p + 32);
+  cache->header.text_len = read_le64(p + 40);
+
+  // Basic validation
+  if (cache->header.uid_index_offset < 48 ||
+      cache->header.name_index_offset < cache->header.uid_index_offset ||
+      cache->header.text_offset < cache->header.name_index_offset ||
+      st.st_size < cache->header.text_offset + cache->header.text_len) {
+    munmap(map, st.st_size);
+    free(cache);
+    return NULL;
+  }
+
+  return cache;
+}
+
+void close_passwd_cache(PasswdCache* cache) {
+  if (cache) {
+    munmap(cache->map, cache->map_size);
+    free(cache);
+  }
+}
+
+// Fills pwd struct and buf from passwd line.
+// line_start points to mmap'd memory, line_len is line length excluding
+// newline. Returns 0 on success, ERANGE if buffer too small, EINVAL if line
+// format invalid.
+static int parse_passwd_line_r(const char* line_start, size_t line_len,
+                               struct passwd* pwd, char* buf, size_t buflen) {
+  const char *token_start, *token_end;
+  const char* line_ptr = line_start;
+  const char* const line_end = line_start + line_len;
+  char* buf_ptr = buf;
+  int field_idx = 0;
+
+  while (line_ptr <= line_end && field_idx < 7) {
+    token_start = line_ptr;
+    token_end = line_ptr;
+    while (token_end < line_end && *token_end != ':') {
+      token_end++;
+    }
+    size_t token_len = token_end - token_start;
+
+    if (field_idx == 2 || field_idx == 3) {  // uid or gid
+      char num_buf[21];                      // enough for 64-bit int
+      if (token_len == 0 || token_len >= sizeof(num_buf)) return EINVAL;
+      memcpy(num_buf, token_start, token_len);
+      num_buf[token_len] = '\0';
+      char* endp;
+      unsigned long val = strtoul(num_buf, &endp, 10);
+      if (*endp != '\0') return EINVAL;
+      if (field_idx == 2) {
+        pwd->pw_uid = val;
+      } else {
+        pwd->pw_gid = val;
+      }
+    } else {  // string field
+      if ((buf + buflen) - buf_ptr < token_len + 1) return ERANGE;
+      memcpy(buf_ptr, token_start, token_len);
+      buf_ptr[token_len] = '\0';
+      if (field_idx == 0)
+        pwd->pw_name = buf_ptr;
+      else if (field_idx == 1)
+        pwd->pw_passwd = buf_ptr;
+      else if (field_idx == 4)
+        pwd->pw_gecos = buf_ptr;
+      else if (field_idx == 5)
+        pwd->pw_dir = buf_ptr;
+      else if (field_idx == 6)
+        pwd->pw_shell = buf_ptr;
+      buf_ptr += token_len + 1;
+    }
+
+    field_idx++;
+    line_ptr = token_end + 1;
+  }
+
+  if (field_idx != 7) return EINVAL;
+
+  return 0;
+}
+
+struct line_info {
+  const char* start;
+  size_t len;
+};
+
+static int get_line_info(PasswdCache* cache, uint64_t offset,
+                         struct line_info* info) {
+  if (offset < cache->header.text_offset ||
+      offset >= cache->header.text_offset + cache->header.text_len) {
+    return -1;
+  }
+  size_t text_len = cache->header.text_len;
+  const char* line_start = (const char*)cache->map + offset;
+  size_t line_offset_in_text = offset - cache->header.text_offset;
+
+  const char* nl =
+      (const char*)memchr(line_start, '\n', text_len - line_offset_in_text);
+  size_t len = nl ? (nl - line_start) : (text_len - line_offset_in_text);
+  info->start = line_start;
+  info->len = len;
+  return 0;
+}
+
+enum nss_status lookup_passwd_by_uid_r(PasswdCache* cache, uid_t uid,
+                                       struct passwd* result, char* buffer,
+                                       size_t buflen, int* errnop) {
+  if (!cache) {
+    *errnop = ENOENT;
+    return NSS_STATUS_UNAVAIL;
+  }
+  if (cache->header.uid_index_len == 0) {
+    *errnop = 0;
+    return NSS_STATUS_NOTFOUND;
+  }
+
+  size_t k = 0;
+  uint8_t* base = (uint8_t*)cache->map + cache->header.uid_index_offset;
+  size_t count = cache->header.uid_index_len;
+  const size_t stride = 8 + 4;
+
+  while (k < count) {
+    uint32_t current_uid = read_le32(base + k * stride + 8);
+    if (current_uid == uid) {
+      uint64_t offset = read_le64(base + k * stride);
+      struct line_info info;
+      if (get_line_info(cache, offset, &info) != 0) {
+        *errnop = EINVAL;
+        return NSS_STATUS_TRYAGAIN;
+      }
+      int rc = parse_passwd_line_r(
+          info.start, info.len, result, buffer, buflen);
+      if (rc == 0) {
+        *errnop = 0;
+        return NSS_STATUS_SUCCESS;
+      } else {
+        *errnop = rc;
+        return NSS_STATUS_TRYAGAIN;
+      }
+    } else if (uid < current_uid) {
+      k = 2 * k + 1;
+    } else {
+      k = 2 * k + 2;
+    }
+  }
+  *errnop = 0;
+  return NSS_STATUS_NOTFOUND;
+}
+
+enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
+                                        struct passwd* result, char* buffer,
+                                        size_t buflen, int* errnop) {
+  if (!cache) {
+    *errnop = ENOENT;
+    return NSS_STATUS_UNAVAIL;
+  }
+  if (cache->header.name_index_len == 0) {
+    *errnop = 0;
+    return NSS_STATUS_NOTFOUND;
+  }
+
+  size_t name_len = strlen(name);
+  uint64_t current_offset = cache->header.name_index_offset;
+  uint8_t* base = (uint8_t*)cache->map;
+
+  while (current_offset != 0 && current_offset < cache->header.text_offset) {
+    uint64_t text_offset = read_le64(base + current_offset);
+    uint64_t left_offset = read_le64(base + current_offset + 8);
+    uint64_t right_offset = read_le64(base + current_offset + 16);
+    uint16_t current_name_len = read_le16(base + current_offset + 24);
+    const char* current_name = (const char*)(base + current_offset + 26);
+
+    // The comparison logic here implements lexicographical string comparison
+    // for BST traversal. We first compare up to the minimum length of the
+    // two strings. If they are identical up to that point (cmp == 0),
+    // it means one string is a prefix of the other, or they are identical.
+    // In lexicographical order, the shorter string comes first, so if
+    // lengths differ, we adjust cmp accordingly (e.g., "user" < "username").
+    int cmp;
+    size_t min_len = name_len < current_name_len ? name_len : current_name_len;
+    cmp = memcmp(name, current_name, min_len);
+    if (cmp == 0) {
+      if (name_len == current_name_len) {
+        struct line_info info;
+        if (get_line_info(cache, text_offset, &info) != 0) {
+          *errnop = EINVAL;
+          return NSS_STATUS_TRYAGAIN;
+        }
+        int rc =
+            parse_passwd_line_r(info.start, info.len, result, buffer, buflen);
+        if (rc == 0) {
+          *errnop = 0;
+          return NSS_STATUS_SUCCESS;
+        } else {
+          *errnop = rc;
+          return NSS_STATUS_TRYAGAIN;
+        }
+      }
+      cmp = name_len < current_name_len ? -1 : 1;
+    }
+
+    if (cmp < 0) {
+      current_offset = left_offset;
+    } else {
+      current_offset = right_offset;
+    }
+  }
+
+  *errnop = 0;
+  return NSS_STATUS_NOTFOUND;
+}
+
+void passwd_cache_iter_begin(PasswdCache* cache, PasswdCacheIter* iter) {
+  if (cache && iter && cache->header.text_len > 0) {
+    iter->internal_offset_ = cache->header.text_offset;
+  } else if (iter) {
+    iter->internal_offset_ = (uint64_t)-1;
+  }
+}
+
+enum nss_status passwd_cache_iter_next_r(PasswdCache* cache,
+                                         PasswdCacheIter* iter,
+                                         struct passwd* result, char* buffer,
+                                         size_t buflen, int* errnop) {
+  if (!cache) {
+    *errnop = ENOENT;
+    return NSS_STATUS_UNAVAIL;
+  }
+  if (!iter || iter->internal_offset_ == (uint64_t)-1) {
+    *errnop = 0;
+    return NSS_STATUS_NOTFOUND;
+  }
+  if (iter->internal_offset_ < cache->header.text_offset ||
+      iter->internal_offset_ >=
+          cache->header.text_offset + cache->header.text_len) {
+    // If offset is out of bounds for any reason, stop iteration.
+    iter->internal_offset_ = (uint64_t)-1;
+    *errnop = 0;
+    return NSS_STATUS_NOTFOUND;
+  }
+
+  // Find line info for current offset
+  size_t text_len = cache->header.text_len;
+  const char* line_start = (const char*)cache->map + iter->internal_offset_;
+  size_t line_offset_in_text =
+      iter->internal_offset_ - cache->header.text_offset;
+  const char* nl =
+      (const char*)memchr(line_start, '\n', text_len - line_offset_in_text);
+  size_t line_len = nl ? (nl - line_start) : (text_len - line_offset_in_text);
+
+  // Parse entry
+  int rc = parse_passwd_line_r(line_start, line_len, result, buffer, buflen);
+  if (rc != 0) {
+    *errnop = rc;
+    return NSS_STATUS_TRYAGAIN;
+  }
+
+  // Advance iterator to start of next line, or -1 if end of text.
+  if (nl) {
+    iter->internal_offset_ = (nl + 1) - (const char*)cache->map;
+    if (iter->internal_offset_ >=
+        cache->header.text_offset + cache->header.text_len) {
+      // If we are at or past the end, finish.
+      iter->internal_offset_ = (uint64_t)-1;
+    }
+  } else {
+    // No newline found, this must have been the last line.
+    iter->internal_offset_ = (uint64_t)-1;
+  }
+
+  *errnop = 0;
+  return NSS_STATUS_SUCCESS;
+}
+
+uint64_t get_passwd_cache_uid_count(PasswdCache* cache) {
+  if (!cache) return 0;
+  return cache->header.uid_index_len;
+}
+
+uint64_t get_passwd_cache_name_count(PasswdCache* cache) {
+  if (!cache) return 0;
+  return cache->header.name_index_len;
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,13 +1,17 @@
 TOPDIR = $(realpath ..)
 
 ifeq ($(GTEST_DIR),)
-GTEST_DIR = /usr/src/googletest/googletest/
+GTEST_DIR = /usr/src/googletest/googletest
 endif
 
+VPATH = $(TOPDIR)/src:$(TOPDIR)/src/nss:$(TOPDIR)/src/cache_refresh
+
 TEST_RUNNER = ./test_runner --gtest_output=xml
+CACHE_TEST_RUNNER = ./cache_test_runner --gtest_output=xml
 SSHCA_TEST_RUNNER = ./sshca_runner --gtest_output=xml --gtest_filter="SSHCATests.*"
-CPPFLAGS += -I$(TOPDIR)/src/include -I/usr/include/json-c -I$(GTEST_DIR) -isystem $(GTEST_DIR)/include
+CPPFLAGS += -I$(TOPDIR)/src -I$(TOPDIR)/src/include -I/usr/include/json-c -I$(GTEST_DIR) -I$(GTEST_DIR)/../googlemock -isystem $(GTEST_DIR)/include -isystem $(GTEST_DIR)/../googlemock/include
 CXXFLAGS += -g -Wall -Wextra
+CFLAGS += -Wall -g -fPIC -Wstrict-prototypes -I$(TOPDIR)/src/include
 LDLIBS = -lcurl -ljson-c -lpthread
 
 .PHONY: all clean alltests ping reset
@@ -22,10 +26,19 @@ clean :
 gtest-all.o: $(GTEST_DIR)/src/gtest-all.cc
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $^
 
-test_runner: oslogin_utils_test.o $(TOPDIR)/src/oslogin_utils.o gtest-all.o
+gmock-all.o: $(GTEST_DIR)/../googlemock/src/gmock-all.cc
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $^
+
+gtest_main.o: $(GTEST_DIR)/src/gtest_main.cc
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $^
+
+cache_test_runner: eytzinger_layout_test.o oslogin_passwd_cache_reader_test.o round_trip_test.o oslogin_passwd_cache_reader.o oslogin_passwd_cache_writer.o gtest-all.o gmock-all.o gtest_main.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
-sshca_runner: oslogin_sshca_test.o $(TOPDIR)/src/oslogin_utils.o $(TOPDIR)/src/oslogin_sshca.o gtest-all.o
+test_runner: oslogin_utils_test.o oslogin_utils.o gtest-all.o gtest_main.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
+
+sshca_runner: oslogin_sshca_test.o $(TOPDIR)/src/oslogin_utils.o $(TOPDIR)/src/oslogin_sshca.o gtest-all.o gtest_main.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
 sshca_tests: sshca_runner
@@ -38,8 +51,9 @@ network_tests: test_runner ping reset
 	$(TEST_RUNNER) --gtest_filter=GetGroupByTest.*:GetUsersForGroupTest.*
 
 # run as $ make tests GTESTARGS="--gtest_filter=GetGroupByTest.*"
-alltests: test_runner
+alltests: test_runner cache_test_runner
 	$(TEST_RUNNER) ${GTESTARGS}
+	$(CACHE_TEST_RUNNER) ${GTESTARGS}
 
 ping:
 	nc -vzw2 169.254.169.254 80 >/dev/null 2>&1

--- a/test/eytzinger_layout_test.cc
+++ b/test/eytzinger_layout_test.cc
@@ -1,0 +1,179 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "eytzinger_layout.h"
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "oslogin_index_structs.h"
+
+namespace {
+
+// Helper to create UID input vector
+std::vector<OsLoginIndexUID> CreateUidVector(const std::vector<uid_t>& uids) {
+  std::vector<OsLoginIndexUID> vec;
+  vec.reserve(uids.size());
+  for (uid_t uid : uids) {
+    vec.push_back({.text_offset = 0, .uid = uid});
+  }
+  return vec;
+}
+
+// Helper to create Name input vector
+std::vector<OsLoginIndexName> CreateNameVector(
+    const std::vector<std::string>& names) {
+  std::vector<OsLoginIndexName> vec;
+  vec.reserve(names.size());
+  for (const std::string& name : names) {
+    vec.push_back({.left_child_offset = 0,
+                   .right_child_offset = 0,
+                   .text_offset = 0,
+                   .name_len = 0,
+                   .name = name,
+                   .self_offset = 0});
+  }
+  return vec;
+}
+
+TEST(EytzingerLayoutTest, EmptyVector) {
+  std::vector<OsLoginIndexUID> uid_vector;
+  auto result = to_eytzinger_layout(uid_vector);
+  EXPECT_TRUE(result.empty());
+
+  std::vector<OsLoginIndexName> name_vector;
+  auto result_name = to_eytzinger_layout(name_vector);
+  EXPECT_TRUE(result_name.empty());
+}
+
+TEST(EytzingerLayoutTest, SingleElement) {
+  auto result = to_eytzinger_layout(CreateUidVector({10}));
+  ASSERT_EQ(1, result.size());
+  EXPECT_EQ(10, result[0].uid);
+
+  auto result_name = to_eytzinger_layout(CreateNameVector({"a"}));
+  ASSERT_EQ(1, result_name.size());
+  EXPECT_EQ("a", result_name[0].name);
+}
+
+TEST(EytzingerLayoutTest, ThreeElements) {
+  auto result = to_eytzinger_layout(CreateUidVector({10, 20, 30}));
+  ASSERT_EQ(3, result.size());
+  EXPECT_EQ(20, result[0].uid);
+  EXPECT_EQ(10, result[1].uid);
+  EXPECT_EQ(30, result[2].uid);
+
+  auto result_name = to_eytzinger_layout(CreateNameVector({"a", "b", "c"}));
+  ASSERT_EQ(3, result_name.size());
+  EXPECT_EQ("b", result_name[0].name);
+  EXPECT_EQ("a", result_name[1].name);
+  EXPECT_EQ("c", result_name[2].name);
+}
+
+TEST(EytzingerLayoutTest, SevenElements) {
+  auto result =
+      to_eytzinger_layout(CreateUidVector({10, 20, 30, 40, 50, 60, 70}));
+  ASSERT_EQ(7, result.size());
+  EXPECT_EQ(40, result[0].uid);
+  EXPECT_EQ(20, result[1].uid);
+  EXPECT_EQ(60, result[2].uid);
+  EXPECT_EQ(10, result[3].uid);
+  EXPECT_EQ(30, result[4].uid);
+  EXPECT_EQ(50, result[5].uid);
+  EXPECT_EQ(70, result[6].uid);
+
+  auto result_name = to_eytzinger_layout(
+      CreateNameVector({"a", "b", "c", "d", "e", "f", "g"}));
+  ASSERT_EQ(7, result_name.size());
+  EXPECT_EQ("d", result_name[0].name);
+  EXPECT_EQ("b", result_name[1].name);
+  EXPECT_EQ("f", result_name[2].name);
+  EXPECT_EQ("a", result_name[3].name);
+  EXPECT_EQ("c", result_name[4].name);
+  EXPECT_EQ("e", result_name[5].name);
+  EXPECT_EQ("g", result_name[6].name);
+}
+
+TEST(EytzingerLayoutTest, TwoElements) {
+  auto result = to_eytzinger_layout(CreateUidVector({10, 20}));
+  ASSERT_EQ(2, result.size());
+  EXPECT_EQ(20, result[0].uid);
+  EXPECT_EQ(10, result[1].uid);
+
+  auto result_name = to_eytzinger_layout(CreateNameVector({"a", "b"}));
+  ASSERT_EQ(2, result_name.size());
+  EXPECT_EQ("b", result_name[0].name);
+  EXPECT_EQ("a", result_name[1].name);
+}
+
+TEST(EytzingerLayoutTest, FourElements) {
+  auto result = to_eytzinger_layout(CreateUidVector({10, 20, 30, 40}));
+  ASSERT_EQ(4, result.size());
+  EXPECT_EQ(30, result[0].uid);
+  EXPECT_EQ(20, result[1].uid);
+  EXPECT_EQ(40, result[2].uid);
+  EXPECT_EQ(10, result[3].uid);
+
+  auto result_name =
+      to_eytzinger_layout(CreateNameVector({"a", "b", "c", "d"}));
+  ASSERT_EQ(4, result_name.size());
+  EXPECT_EQ("c", result_name[0].name);
+  EXPECT_EQ("b", result_name[1].name);
+  EXPECT_EQ("d", result_name[2].name);
+  EXPECT_EQ("a", result_name[3].name);
+}
+
+TEST(EytzingerLayoutTest, FiveElements) {
+  auto result = to_eytzinger_layout(CreateUidVector({10, 20, 30, 40, 50}));
+  ASSERT_EQ(5, result.size());
+  EXPECT_EQ(40, result[0].uid);
+  EXPECT_EQ(20, result[1].uid);
+  EXPECT_EQ(50, result[2].uid);
+  EXPECT_EQ(10, result[3].uid);
+  EXPECT_EQ(30, result[4].uid);
+
+  auto result_name =
+      to_eytzinger_layout(CreateNameVector({"a", "b", "c", "d", "e"}));
+  ASSERT_EQ(5, result_name.size());
+  EXPECT_EQ("d", result_name[0].name);
+  EXPECT_EQ("b", result_name[1].name);
+  EXPECT_EQ("e", result_name[2].name);
+  EXPECT_EQ("a", result_name[3].name);
+  EXPECT_EQ("c", result_name[4].name);
+}
+
+TEST(EytzingerLayoutTest, SixElements) {
+  auto result = to_eytzinger_layout(CreateUidVector({10, 20, 30, 40, 50, 60}));
+  ASSERT_EQ(6, result.size());
+  EXPECT_EQ(40, result[0].uid);
+  EXPECT_EQ(20, result[1].uid);
+  EXPECT_EQ(60, result[2].uid);
+  EXPECT_EQ(10, result[3].uid);
+  EXPECT_EQ(30, result[4].uid);
+  EXPECT_EQ(50, result[5].uid);
+
+  auto result_name =
+      to_eytzinger_layout(CreateNameVector({"a", "b", "c", "d", "e", "f"}));
+  ASSERT_EQ(6, result_name.size());
+  EXPECT_EQ("d", result_name[0].name);
+  EXPECT_EQ("b", result_name[1].name);
+  EXPECT_EQ("f", result_name[2].name);
+  EXPECT_EQ("a", result_name[3].name);
+  EXPECT_EQ("c", result_name[4].name);
+  EXPECT_EQ("e", result_name[5].name);
+}
+
+}  // namespace

--- a/test/oslogin_passwd_cache_reader_test.cc
+++ b/test/oslogin_passwd_cache_reader_test.cc
@@ -1,0 +1,48 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "oslogin_passwd_cache_reader.h"
+
+#include <cerrno>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <nss.h>
+#include <pwd.h>
+
+namespace {
+
+TEST(OsLoginPasswdCacheReaderTest, MissingFile) {
+  std::string temp_dir = ::testing::TempDir();
+  std::string missing_filename = temp_dir + "/no_such_file.cache";
+
+  PasswdCache* cache = open_passwd_cache(missing_filename.c_str());
+  EXPECT_EQ(cache, nullptr);
+
+  struct passwd pwd;
+  char buf[1024];
+  int errnop;
+
+  EXPECT_EQ(NSS_STATUS_UNAVAIL,
+            lookup_passwd_by_uid_r(
+                nullptr, 1000, &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(ENOENT, errnop);
+
+  EXPECT_EQ(NSS_STATUS_UNAVAIL,
+            lookup_passwd_by_name_r(nullptr, "user1000", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(ENOENT, errnop);
+}
+
+}  // namespace

--- a/test/oslogin_utils_test.cc
+++ b/test/oslogin_utils_test.cc
@@ -644,7 +644,3 @@ TEST(ParseJsonToGroupsTest, TestGroups) {
 }
 
 }  // namespace oslogin_utils
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/round_trip_test.cc
+++ b/test/round_trip_test.cc
@@ -1,0 +1,543 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <fstream>
+#include <ios>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <nss.h>
+#include <pwd.h>
+
+#include <gtest/gtest.h>
+
+#include "oslogin_passwd_cache_reader.h"
+#include "oslogin_passwd_cache_writer.h"
+
+namespace {
+
+class RoundTripTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::string temp_dir = ::testing::TempDir();
+    filename_ = temp_dir + "/passwd.cache";
+    std::string tmp_filename = temp_dir + "/passwd.cache.tmp";
+
+    OsLoginPasswdCacheWriter writer;
+    writer.AddUser("root", "x", 0, 0, "Root", "/", "/bin/bash");
+    for (int i = 1000; i < 3000; ++i) {
+      std::string user = "user" + std::to_string(i);
+      std::string gecos = "User " + std::to_string(i);
+      std::string home = "/home/" + user;
+      writer.AddUser(user, "x", i, i, gecos, home, "/bin/bash");
+    }
+    std::ofstream out(tmp_filename, std::ios::binary);
+    ASSERT_TRUE(writer.Commit(out));
+    out.close();
+    ASSERT_EQ(0, rename(tmp_filename.c_str(), filename_.c_str()));
+
+    cache_ = open_passwd_cache(filename_.c_str());
+    ASSERT_NE(cache_, nullptr);
+  }
+
+  void TearDown() override {
+    if (cache_) {
+      close_passwd_cache(cache_);
+    }
+  }
+
+  void WriteUsers(int revision) {
+    std::string temp_dir = ::testing::TempDir();
+    std::string tmp_filename =
+        temp_dir + "/passwd.cache.tmp." + std::to_string(revision);
+
+    OsLoginPasswdCacheWriter writer;
+    writer.AddUser("root", "x", 0, 0, "Root", "/", "/bin/bash");
+    for (int i = 1000; i < 3000; ++i) {
+      std::string user = "user" + std::to_string(i);
+      std::string gecos =
+          "User " + std::to_string(i) + " rev " + std::to_string(revision);
+      std::string home = "/home/" + user;
+      writer.AddUser(user, "x", i, i, gecos, home, "/bin/bash");
+    }
+    // Add a revision-specific user.
+    writer.AddUser("user_rev" + std::to_string(revision), "x", 3000 + revision,
+                   3000 + revision, "Rev user", "/", "/bin/bash");
+    std::ofstream out(tmp_filename, std::ios::binary);
+    ASSERT_TRUE(writer.Commit(out));
+    out.close();
+    ASSERT_EQ(0, rename(tmp_filename.c_str(), filename_.c_str()));
+  }
+
+  std::string filename_;
+  PasswdCache* cache_ = nullptr;
+};
+
+TEST_F(RoundTripTest, WriteAndRead) {
+  ASSERT_EQ(2001, get_passwd_cache_uid_count(cache_));
+  ASSERT_EQ(2001, get_passwd_cache_name_count(cache_));
+
+  // Test UID lookup
+  struct passwd pwd;
+  char buf[2048];
+  int errnop;
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_uid_r(cache_, 1500, &pwd, buf, sizeof(buf),
+                                   &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("user1500", pwd.pw_name);
+  EXPECT_EQ(1500, pwd.pw_uid);
+  EXPECT_EQ(1500, pwd.pw_gid);
+  EXPECT_STREQ("x", pwd.pw_passwd);
+  EXPECT_STREQ("User 1500", pwd.pw_gecos);
+  EXPECT_STREQ("/home/user1500", pwd.pw_dir);
+  EXPECT_STREQ("/bin/bash", pwd.pw_shell);
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_uid_r(cache_, 2500, &pwd, buf, sizeof(buf),
+                                   &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("user2500", pwd.pw_name);
+  EXPECT_EQ(2500, pwd.pw_uid);
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_uid_r(cache_, 0, &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("root", pwd.pw_name);
+  EXPECT_EQ(0, pwd.pw_uid);
+
+  // Non-existent
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_uid_r(cache_, 9999, &pwd, buf, sizeof(buf),
+                                   &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_uid_r(cache_, 999, &pwd, buf, sizeof(buf),
+                                   &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_uid_r(cache_, 3000, &pwd, buf, sizeof(buf),
+                                   &errnop));
+
+  // Test name lookup
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(cache_, "user1500", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("user1500", pwd.pw_name);
+  EXPECT_EQ(1500, pwd.pw_uid);
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(cache_, "user2500", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("user2500", pwd.pw_name);
+  EXPECT_EQ(2500, pwd.pw_uid);
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(cache_, "root", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("root", pwd.pw_name);
+  EXPECT_EQ(0, pwd.pw_uid);
+
+  // Non-existent
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(cache_, "nouser", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(cache_, "a", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(cache_, "user", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(cache_, "user10000", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(cache_, "zzzz", &pwd, buf, sizeof(buf),
+                                    &errnop));
+
+  // Test buffer too small
+  EXPECT_EQ(NSS_STATUS_TRYAGAIN,
+            lookup_passwd_by_uid_r(cache_, 0, &pwd, buf, 10, &errnop));
+  EXPECT_EQ(ERANGE, errnop);
+}
+
+TEST_F(RoundTripTest, ERangeNegotiation) {
+  struct passwd pwd;
+  char buf[24];  // Just enough for root user
+  int errnop;
+
+  // Buffer 23 should be too small for root user
+  EXPECT_EQ(NSS_STATUS_TRYAGAIN,
+            lookup_passwd_by_uid_r(cache_, 0, &pwd, buf, 23, &errnop));
+  EXPECT_EQ(ERANGE, errnop);
+
+  // Buffer 24 should be just enough for root user
+  EXPECT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_uid_r(cache_, 0, &pwd, buf, 24, &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("root", pwd.pw_name);
+  EXPECT_STREQ("x", pwd.pw_passwd);
+  EXPECT_STREQ("Root", pwd.pw_gecos);
+  EXPECT_STREQ("/", pwd.pw_dir);
+  EXPECT_STREQ("/bin/bash", pwd.pw_shell);
+
+  // Lookup by name too
+  EXPECT_EQ(NSS_STATUS_TRYAGAIN,
+            lookup_passwd_by_name_r(cache_, "root", &pwd, buf, 23, &errnop));
+  EXPECT_EQ(ERANGE, errnop);
+  EXPECT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(cache_, "root", &pwd, buf, 24, &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("root", pwd.pw_name);
+}
+
+TEST_F(RoundTripTest, NamePrefixLookup) {
+  std::string temp_dir = ::testing::TempDir();
+  std::string filename = temp_dir + "/prefix.cache";
+  std::string tmp_filename = temp_dir + "/prefix.cache.tmp";
+
+  OsLoginPasswdCacheWriter writer;
+  writer.AddUser("a", "x", 1, 1, "", "/", "");
+  writer.AddUser("b", "x", 2, 2, "", "/", "");
+  writer.AddUser("bar", "x", 3, 3, "", "/", "");
+  writer.AddUser("bart", "x", 4, 4, "", "/", "");
+  writer.AddUser("baz", "x", 5, 5, "", "/", "");
+  writer.AddUser("foo", "x", 6, 6, "", "/", "");
+  std::ofstream out(tmp_filename, std::ios::binary);
+  ASSERT_TRUE(writer.Commit(out));
+  out.close();
+  ASSERT_EQ(0, rename(tmp_filename.c_str(), filename.c_str()));
+
+  PasswdCache* cache = open_passwd_cache(filename.c_str());
+  ASSERT_NE(cache, nullptr);
+
+  struct passwd pwd;
+  char buf[1024];
+  int errnop;
+
+  // Test successful lookups
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(
+                cache, "a", &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(1, pwd.pw_uid);
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(
+                cache, "b", &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(2, pwd.pw_uid);
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(
+                cache, "bar", &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(3, pwd.pw_uid);
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(
+                cache, "bart", &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(4, pwd.pw_uid);
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(
+                cache, "baz", &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(5, pwd.pw_uid);
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(
+                cache, "foo", &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(6, pwd.pw_uid);
+
+  // Test non-existent lookups, including prefixes and extensions
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(
+                cache, "ba", &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(
+                cache, "bartender", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(
+                cache, "fo", &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(
+                cache, "foobar", &pwd, buf, sizeof(buf),
+                                    &errnop));
+
+  close_passwd_cache(cache);
+}
+
+TEST_F(RoundTripTest, Iteration) {
+  PasswdCacheIter iter;
+  struct passwd pwd;
+  char buf[2048];
+  int errnop;
+  int count = 0;
+
+  // Test ERange first
+  passwd_cache_iter_begin(cache_, &iter);
+  char small_buf[10];
+  EXPECT_EQ(NSS_STATUS_TRYAGAIN,
+            passwd_cache_iter_next_r(cache_, &iter, &pwd, small_buf,
+                                     sizeof(small_buf), &errnop));
+  EXPECT_EQ(ERANGE, errnop);
+
+  // Retry with large buffer - should return first entry "root" because
+  // iterator should not advance on TRYAGAIN.
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            passwd_cache_iter_next_r(
+                cache_, &iter, &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("root", pwd.pw_name);
+  count++;
+
+  // Next users 1000-2999
+  for (int i = 1000; i < 3000; ++i) {
+    ASSERT_EQ(NSS_STATUS_SUCCESS,
+              passwd_cache_iter_next_r(
+                  cache_, &iter, &pwd, buf, sizeof(buf), &errnop));
+    EXPECT_EQ(0, errnop);
+    EXPECT_EQ(i, pwd.pw_uid);
+    std::string expected_name = "user" + std::to_string(i);
+    EXPECT_STREQ(expected_name.c_str(), pwd.pw_name);
+    count++;
+  }
+
+  // Should be no more entries
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            passwd_cache_iter_next_r(
+                cache_, &iter, &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(2001, count);
+
+  // Calling again should still return NOTFOUND
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            passwd_cache_iter_next_r(
+                cache_, &iter, &pwd, buf, sizeof(buf), &errnop));
+
+  // Test reset with begin()
+  passwd_cache_iter_begin(cache_, &iter);
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            passwd_cache_iter_next_r(
+                cache_, &iter, &pwd, buf, sizeof(buf), &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("root", pwd.pw_name);
+}
+
+TEST_F(RoundTripTest, ConcurrentLookups) {
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 16; ++i) {
+    threads.emplace_back([this, i]() {
+      struct passwd pwd;
+      char buf[2048];
+      int errnop;
+      const int kStride = 31;
+      const int kUsers = 2000;
+      for (int j = 0; j < 1000; ++j) {
+        // Lookup users known to exist
+        uid_t uid_to_find = 1000 + (i + j * kStride) % kUsers;
+        ASSERT_EQ(NSS_STATUS_SUCCESS,
+                  lookup_passwd_by_uid_r(
+                      cache_, uid_to_find, &pwd, buf,
+                                           sizeof(buf), &errnop));
+        EXPECT_EQ(0, errnop);
+        EXPECT_EQ(uid_to_find, pwd.pw_uid);
+        std::string expected_name = "user" + std::to_string(uid_to_find);
+        EXPECT_STREQ(expected_name.c_str(), pwd.pw_name);
+
+        const std::string name_to_find =
+            "user" + std::to_string(1000 + (i + 100 + j * kStride) % kUsers);
+        ASSERT_EQ(NSS_STATUS_SUCCESS,
+                  lookup_passwd_by_name_r(cache_, name_to_find.c_str(), &pwd,
+                                            buf, sizeof(buf), &errnop));
+        EXPECT_EQ(0, errnop);
+        EXPECT_STREQ(name_to_find.c_str(), pwd.pw_name);
+
+        // Lookup non-existent
+        EXPECT_EQ(NSS_STATUS_NOTFOUND,
+                  lookup_passwd_by_uid_r(cache_,
+                      3000 + (i + j * kStride) % kUsers,
+                      &pwd, buf, sizeof(buf), &errnop));
+        EXPECT_EQ(
+            NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(
+                cache_,
+                ("user" + std::to_string(
+                    3000 + (i + 100 + j * kStride) % kUsers))
+                      .c_str(),
+                &pwd, buf, sizeof(buf), &errnop));
+      }
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+TEST_F(RoundTripTest, ConcurrentReadWithAtomicUpdate) {
+  std::atomic<bool> done{false};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 16; ++i) {
+    threads.emplace_back([this, &done, i]() {
+      struct passwd pwd;
+      char buf[2048];
+      int errnop;
+      const int kStride = 31;
+      const int kUsers = 2000;
+      int j = 0;
+      while (!done) {
+        uid_t uid_to_find = 1000 + (i + j * kStride) % kUsers;
+        auto status = lookup_passwd_by_uid_r(cache_, uid_to_find, &pwd, buf,
+                                             sizeof(buf), &errnop);
+        // We must either succeed or fail with NOTFOUND.
+        // TRYAGAIN is only OK if buffer is too small (ERANGE), not if
+        // data is corrupt (EINVAL).
+        ASSERT_TRUE(status == NSS_STATUS_SUCCESS ||
+                    status == NSS_STATUS_NOTFOUND ||
+                    (status == NSS_STATUS_TRYAGAIN && errnop == ERANGE));
+        if (status == NSS_STATUS_SUCCESS) {
+          EXPECT_EQ(uid_to_find, pwd.pw_uid);
+          std::string expected_name = "user" + std::to_string(uid_to_find);
+          EXPECT_STREQ(expected_name.c_str(), pwd.pw_name);
+        }
+
+        // Also check for revision users that are being added by the writer.
+        // They should not be found in our stale mmap view, and looking them
+        // up should be safe (not crash or return corrupt data).
+        int rev_num = j % 5;
+        uid_t rev_uid = 3000 + rev_num;
+        status = lookup_passwd_by_uid_r(cache_, rev_uid, &pwd, buf, sizeof(buf),
+                                        &errnop);
+        ASSERT_TRUE(status == NSS_STATUS_NOTFOUND ||
+                    (status == NSS_STATUS_TRYAGAIN && errnop == ERANGE));
+
+        std::string rev_name = "user_rev" + std::to_string(rev_num);
+        status = lookup_passwd_by_name_r(cache_, rev_name.c_str(), &pwd, buf,
+                                         sizeof(buf), &errnop);
+        ASSERT_TRUE(status == NSS_STATUS_NOTFOUND ||
+                    (status == NSS_STATUS_TRYAGAIN && errnop == ERANGE));
+        j++;
+      }
+    });
+  }
+
+  // While readers are running, update the cache file multiple times.
+  for (int rev = 0; rev < 5; ++rev) {
+    WriteUsers(rev);
+  }
+
+  done = true;
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+TEST_F(RoundTripTest, UnsortedInput) {
+  std::string temp_dir = ::testing::TempDir();
+  std::string filename = temp_dir + "/unsorted.cache";
+  std::string tmp_filename = temp_dir + "/unsorted.cache.tmp";
+
+  OsLoginPasswdCacheWriter writer;
+  writer.AddUser(
+      "user2", "x", 2000, 2000, "User 2", "/home/user2", "/bin/bash");
+  writer.AddUser(
+      "user1", "x", 1000, 1000, "User 1", "/home/user1", "/bin/bash");
+  writer.AddUser(
+      "user3", "x", 3000, 3000, "User 3", "/home/user3", "/bin/bash");
+  std::ofstream out(tmp_filename, std::ios::binary);
+  ASSERT_TRUE(writer.Commit(out));
+  out.close();
+  ASSERT_EQ(0, rename(tmp_filename.c_str(), filename.c_str()));
+
+  PasswdCache* cache = open_passwd_cache(filename.c_str());
+  ASSERT_NE(cache, nullptr);
+
+  ASSERT_EQ(3, get_passwd_cache_uid_count(cache));
+  ASSERT_EQ(3, get_passwd_cache_name_count(cache));
+
+  struct passwd pwd;
+  char buf[1024];
+  int errnop;
+
+  // Verify UID lookups
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_uid_r(cache, 1000, &pwd, buf, sizeof(buf),
+                                   &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("user1", pwd.pw_name);
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_uid_r(cache, 2000, &pwd, buf, sizeof(buf),
+                                   &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("user2", pwd.pw_name);
+
+  ASSERT_EQ(3, get_passwd_cache_uid_count(cache));
+  ASSERT_EQ(3, get_passwd_cache_name_count(cache));
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_uid_r(cache, 3000, &pwd, buf, sizeof(buf),
+                                   &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_STREQ("user3", pwd.pw_name);
+
+  // Verify name lookups
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(cache, "user1", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_EQ(1000, pwd.pw_uid);
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(cache, "user2", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_EQ(2000, pwd.pw_uid);
+
+  ASSERT_EQ(NSS_STATUS_SUCCESS,
+            lookup_passwd_by_name_r(cache, "user3", &pwd, buf, sizeof(buf),
+                                    &errnop));
+  EXPECT_EQ(0, errnop);
+  EXPECT_EQ(3000, pwd.pw_uid);
+
+  close_passwd_cache(cache);
+}
+
+TEST_F(RoundTripTest, EmptyCache) {
+  std::string temp_dir = ::testing::TempDir();
+  std::string filename = temp_dir + "/empty.cache";
+  std::string tmp_filename = temp_dir + "/empty.cache.tmp";
+
+  OsLoginPasswdCacheWriter writer;
+  std::ofstream out(tmp_filename, std::ios::binary);
+  ASSERT_TRUE(writer.Commit(out));
+  out.close();
+  ASSERT_EQ(0, rename(tmp_filename.c_str(), filename.c_str()));
+
+  PasswdCache* cache = open_passwd_cache(filename.c_str());
+  ASSERT_NE(cache, nullptr);
+
+  struct passwd pwd;
+  char buf[1024];
+  int errnop;
+
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_uid_r(cache, 1000, &pwd, buf, sizeof(buf),
+                                   &errnop));
+  EXPECT_EQ(NSS_STATUS_NOTFOUND,
+            lookup_passwd_by_name_r(cache, "user1", &pwd, buf, sizeof(buf),
+                                    &errnop));
+
+  close_passwd_cache(cache);
+}
+
+}  // namespace


### PR DESCRIPTION
This change introduces a new binary cache format for storing OS Login passwd information. It includes:
-   `OsLoginPasswdCacheWriter`: A C++ class to build and write the cache file. It buffers user entries, sorts them, and writes them to a temporary file before atomically renaming it.
-   `oslogin_passwd_cache_reader`: A C implementation for reading from the cache file using mmap. It provides functions compatible with NSS modules for looking up entries by UID, name, and iterating through all entries.
-   `eytzinger_layout.h`: A template function to convert a sorted vector into an Eytzinger layout, used for the name index to improve cache locality during lookups.
-   `oslogin_index_structs.h`: Defines the structures used for the UID and Name indices.
-   New unit tests (`eytzinger_layout_test.cc`, `oslogin_passwd_cache_reader_test.cc`, `round_trip_test.cc`) to validate the cache functionality, including concurrent read access.
-   The `Makefile` is updated to build and run the new tests. The `main` function is removed from `oslogin_utils_test.cc` as `gtest_main.cc` is now linked.