### PR TITLE
Check and properly pad the buffer used for usernames in the NSS module, properly support buffer size negotiation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 google_authorized_keys
 google_authorized_keys_sk
 google_oslogin_nss_cache
+test/nss_test_runner
 test/sshca_runner
 test/test_detail.xml
 selinux/oslogin.mod

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test/sshca_runner
 test/test_detail.xml
 selinux/oslogin.mod
 selinux/oslogin.pp
+test/cache_test_runner
 test/new_test_runner
 test/test_runner
 src/google_authorized_principals

--- a/src/nss/nss_cache_oslogin.c
+++ b/src/nss/nss_cache_oslogin.c
@@ -366,6 +366,11 @@ _nss_cache_oslogin_getgrent_r(struct group *result, char *buffer,
   return ret;
 }
 
+#define CALCULATE_PADDING_FOR_ALIGNMENT(buf_addr, bytes_to_write)              \
+  ((__alignof__(char *) -                                                      \
+    (((size_t)(buf_addr) + (bytes_to_write)) % __alignof__(char *))) %         \
+   __alignof__(char *))
+
 // _nss_cache_oslogin_getgrgid_r()
 // Find a group by gid
 
@@ -382,9 +387,7 @@ _nss_cache_oslogin_getgrgid_r(gid_t gid, struct group *result,
   if (ret == NSS_STATUS_SUCCESS && user.pw_gid == user.pw_uid) {
     size_t name_len = strlen(user.pw_name) + 1;
     size_t bytes_needed = 2 + name_len;
-    size_t alignment = __alignof__(char *);
-    size_t misalign = ((size_t)buffer + bytes_needed) % alignment;
-    size_t padding = misalign ? (alignment - misalign) : 0;
+    size_t padding = CALCULATE_PADDING_FOR_ALIGNMENT(buffer, bytes_needed);
     bytes_needed += padding + 2 * sizeof(char *);
 
     if (buflen < bytes_needed) {
@@ -445,9 +448,7 @@ _nss_cache_oslogin_getgrnam_r(const char *name, struct group *result,
   if (ret == NSS_STATUS_SUCCESS && user.pw_gid == user.pw_uid) {
     size_t name_len = strlen(user.pw_name) + 1;
     size_t bytes_needed = 2 + name_len;
-    size_t alignment = __alignof__(char *);
-    size_t misalign = ((size_t)buffer + bytes_needed) % alignment;
-    size_t padding = misalign ? (alignment - misalign) : 0;
+    size_t padding = CALCULATE_PADDING_FOR_ALIGNMENT(buffer, bytes_needed);
     bytes_needed += padding + 2 * sizeof(char *);
 
     if (buflen < bytes_needed) {

--- a/src/nss/nss_cache_oslogin.c
+++ b/src/nss/nss_cache_oslogin.c
@@ -380,6 +380,18 @@ _nss_cache_oslogin_getgrgid_r(gid_t gid, struct group *result,
   char userbuf[userbuflen];
   ret = _nss_cache_oslogin_getpwuid_r(gid, &user, userbuf, userbuflen, errnop);
   if (ret == NSS_STATUS_SUCCESS && user.pw_gid == user.pw_uid) {
+    size_t name_len = strlen(user.pw_name) + 1;
+    size_t bytes_needed = 2 + name_len;
+    size_t alignment = __alignof__(char *);
+    size_t misalign = ((size_t)buffer + bytes_needed) % alignment;
+    size_t padding = misalign ? (alignment - misalign) : 0;
+    bytes_needed += padding + 2 * sizeof(char *);
+
+    if (buflen < bytes_needed) {
+      *errnop = ERANGE;
+      return NSS_STATUS_TRYAGAIN;
+    }
+
     result->gr_gid = user.pw_gid;
 
     // store "x" for password.
@@ -389,12 +401,11 @@ _nss_cache_oslogin_getgrgid_r(gid_t gid, struct group *result,
 
     // store name.
     string = (char *)((size_t) string + 2);
-    size_t name_len = strlen(user.pw_name)+1;
     strncpy(string, user.pw_name, name_len);
     result->gr_name = string;
 
     // member array starts past strings.
-    char **strarray = (char **)((size_t) string + name_len);
+    char **strarray = (char **)((size_t) string + name_len + padding);
     strarray[0] = string;
     strarray[1] = NULL;
     result->gr_mem = strarray;
@@ -432,6 +443,18 @@ _nss_cache_oslogin_getgrnam_r(const char *name, struct group *result,
   char userbuf[userbuflen];
   ret = _nss_cache_oslogin_getpwnam_r(name, &user, userbuf, userbuflen, errnop);
   if (ret == NSS_STATUS_SUCCESS && user.pw_gid == user.pw_uid) {
+    size_t name_len = strlen(user.pw_name) + 1;
+    size_t bytes_needed = 2 + name_len;
+    size_t alignment = __alignof__(char *);
+    size_t misalign = ((size_t)buffer + bytes_needed) % alignment;
+    size_t padding = misalign ? (alignment - misalign) : 0;
+    bytes_needed += padding + 2 * sizeof(char *);
+
+    if (buflen < bytes_needed) {
+      *errnop = ERANGE;
+      return NSS_STATUS_TRYAGAIN;
+    }
+
     result->gr_gid = user.pw_gid;
 
     // store "x" for password.
@@ -441,12 +464,11 @@ _nss_cache_oslogin_getgrnam_r(const char *name, struct group *result,
 
     // store name.
     string = (char *)((size_t) string + 2);
-    size_t name_len = strlen(user.pw_name)+1;
     strncpy(string, user.pw_name, name_len);
     result->gr_name = string;
 
     // member array starts past strings.
-    char **strarray = (char **)((size_t) string + name_len);
+    char **strarray = (char **)((size_t) string + name_len + padding);
     strarray[0] = string;
     strarray[1] = NULL;
     result->gr_mem = strarray;

--- a/test/Makefile
+++ b/test/Makefile
@@ -41,6 +41,9 @@ test_runner: oslogin_utils_test.o oslogin_utils.o gtest-all.o gtest_main.o
 sshca_runner: oslogin_sshca_test.o $(TOPDIR)/src/oslogin_utils.o $(TOPDIR)/src/oslogin_sshca.o gtest-all.o gtest_main.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
+nss_test_runner: nss_cache_oslogin_test.o nss_cache_oslogin.o gtest-all.o gtest_main.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
+
 sshca_tests: sshca_runner
 	$(SSHCA_TEST_RUNNER)
 

--- a/test/nss_cache_oslogin_test.cc
+++ b/test/nss_cache_oslogin_test.cc
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <grp.h>
+#include <nss.h>
+#include <pwd.h>
+#include <errno.h>
+#include <stdint.h>
+
+// Include the header to get the correct types.
+#include "../src/include/oslogin_passwd_cache_reader.h"
+
+extern "C" {
+enum nss_status _nss_cache_oslogin_getgrgid_r(gid_t gid, struct group *result,
+                                              char *buffer, size_t buflen,
+                                              int *errnop);
+}
+
+extern "C" {
+// Implement the mocked functions.
+PasswdCache* open_passwd_cache(const char* filename) {
+  return reinterpret_cast<PasswdCache*>(0x1234);
+}
+
+void close_passwd_cache(PasswdCache* cache) {}
+
+struct passwd mock_user;
+enum nss_status mock_lookup_status = NSS_STATUS_SUCCESS;
+
+enum nss_status lookup_passwd_by_uid_r(PasswdCache* cache, uid_t uid,
+                                       struct passwd* result, char* buffer,
+                                       size_t buflen, int* errnop) {
+  if (mock_lookup_status == NSS_STATUS_SUCCESS) {
+    *result = mock_user;
+  }
+  return mock_lookup_status;
+}
+
+// Additional stubs to fix linker errors.
+void passwd_cache_iter_begin(PasswdCache* cache, PasswdCacheIter* iter) {}
+
+enum nss_status passwd_cache_iter_next_r(PasswdCache* cache,
+                                         PasswdCacheIter* iter,
+                                         struct passwd* result, char* buffer,
+                                         size_t buflen, int* errnop) {
+  return NSS_STATUS_NOTFOUND;
+}
+
+enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
+                                        struct passwd* result, char* buffer,
+                                        size_t buflen, int* errnop) {
+  return NSS_STATUS_NOTFOUND;
+}
+}
+
+class NssCacheOsloginTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mock_lookup_status = NSS_STATUS_SUCCESS;
+    memset(&mock_user, 0, sizeof(mock_user));
+  }
+};
+
+TEST_F(NssCacheOsloginTest, GetgrgidSelfGroupBufferTooSmall) {
+  static char username[] = "testuser";
+  mock_user.pw_name = username;
+  mock_user.pw_uid = 1001;
+  mock_user.pw_gid = 1001;
+
+  struct group result;
+  char buffer[1];
+  int errnop = 0;
+  
+  enum nss_status status = _nss_cache_oslogin_getgrgid_r(1001, &result, buffer, sizeof(buffer), &errnop);
+  
+  EXPECT_EQ(status, NSS_STATUS_TRYAGAIN);
+  EXPECT_EQ(errnop, ERANGE);
+}
+
+TEST_F(NssCacheOsloginTest, GetgrgidSelfGroupSuccess) {
+  static char username[] = "testuser";
+  mock_user.pw_name = username;
+  mock_user.pw_uid = 1001;
+  mock_user.pw_gid = 1001;
+
+  struct group result;
+  char buffer[1024];
+  int errnop = 0;
+  
+  enum nss_status status = _nss_cache_oslogin_getgrgid_r(1001, &result, buffer, sizeof(buffer), &errnop);
+  
+  EXPECT_EQ(status, NSS_STATUS_SUCCESS);
+  EXPECT_STREQ(result.gr_name, "testuser");
+  EXPECT_STREQ(result.gr_passwd, "x");
+  EXPECT_EQ(result.gr_gid, 1001);
+  EXPECT_STREQ(result.gr_mem[0], "testuser");
+  EXPECT_TRUE(result.gr_mem[1] == NULL);
+}


### PR DESCRIPTION
NSS does not guarantee the minimum size of the buffer passed to these functions. In fact, it's controlled by the calling application (often `glibc` utilities, but not necessarily). The NSS spec also dictates that the implementation *must* return `ERANGE` (which translates to `NSS_STATUS_TRYAGAIN`) to indicate to the caller to try again with a larger buffer. 

This change therefore satisfies a correctness requirement for the NSS protocol to function as intended for buffer size negotiation -- we've so far gotten by on simply having well-behaved callers who give us ample buffer, but this good behaviour is not guaranteed.