### PR TITLE
Add guard to lookup in the users cache, and return UNAVAIL when cache is corrupted.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 google_authorized_keys
 google_authorized_keys_sk
 google_oslogin_nss_cache
+test/cache_test_runner
+test/nss_test_runner
 test/sshca_runner
 test/test_detail.xml
 selinux/oslogin.mod

--- a/src/nss/oslogin_passwd_cache_reader.c
+++ b/src/nss/oslogin_passwd_cache_reader.c
@@ -46,6 +46,10 @@ struct PasswdCache {
   struct passwd_cache_header header;
 };
 
+// Size of the fixed header of a name index node in the cache file.
+// 8 bytes (text_offset) + 8 bytes (left_offset) + 8 bytes (right_offset) + 2 bytes (name_len) = 26 bytes.
+#define NAME_NODE_HEADER_SIZE 26
+
 // Because the file is a binary format, we need special functions to read
 // multi-byte values from the file in the correct endianness.
 static uint16_t read_le16(const uint8_t* p) {
@@ -266,7 +270,7 @@ enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
   uint8_t* base = (uint8_t*)cache->map;
 
   while (current_offset != 0 && current_offset < cache->header.text_offset) {
-    if (current_offset + 26 > cache->map_size) {
+    if (current_offset + NAME_NODE_HEADER_SIZE > cache->map_size) {
       *errnop = EINVAL;
       return NSS_STATUS_TRYAGAIN;
     }
@@ -275,11 +279,11 @@ enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
     uint64_t right_offset = read_le64(base + current_offset + 16);
     uint16_t current_name_len = read_le16(base + current_offset + 24);
 
-    if (current_offset + 26 + current_name_len > cache->map_size) {
+    if (current_offset + NAME_NODE_HEADER_SIZE + current_name_len > cache->map_size) {
       *errnop = EINVAL;
       return NSS_STATUS_TRYAGAIN;
     }
-    const char* current_name = (const char*)(base + current_offset + 26);
+    const char* current_name = (const char*)(base + current_offset + NAME_NODE_HEADER_SIZE);
 
     // The comparison logic here implements lexicographical string comparison
     // for BST traversal. We first compare up to the minimum length of the

--- a/src/nss/oslogin_passwd_cache_reader.c
+++ b/src/nss/oslogin_passwd_cache_reader.c
@@ -266,10 +266,19 @@ enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
   uint8_t* base = (uint8_t*)cache->map;
 
   while (current_offset != 0 && current_offset < cache->header.text_offset) {
+    if (current_offset + 26 > cache->map_size) {
+      *errnop = EINVAL;
+      return NSS_STATUS_TRYAGAIN;
+    }
     uint64_t text_offset = read_le64(base + current_offset);
     uint64_t left_offset = read_le64(base + current_offset + 8);
     uint64_t right_offset = read_le64(base + current_offset + 16);
     uint16_t current_name_len = read_le16(base + current_offset + 24);
+
+    if (current_offset + 26 + current_name_len > cache->map_size) {
+      *errnop = EINVAL;
+      return NSS_STATUS_TRYAGAIN;
+    }
     const char* current_name = (const char*)(base + current_offset + 26);
 
     // The comparison logic here implements lexicographical string comparison

--- a/src/nss/oslogin_passwd_cache_reader.c
+++ b/src/nss/oslogin_passwd_cache_reader.c
@@ -232,16 +232,19 @@ enum nss_status lookup_passwd_by_uid_r(PasswdCache* cache, uid_t uid,
       struct line_info info;
       if (get_line_info(cache, offset, &info) != 0) {
         *errnop = EINVAL;
-        return NSS_STATUS_TRYAGAIN;
+        return NSS_STATUS_UNAVAIL;
       }
       int rc = parse_passwd_line_r(
           info.start, info.len, result, buffer, buflen);
       if (rc == 0) {
         *errnop = 0;
         return NSS_STATUS_SUCCESS;
-      } else {
+      } else if (rc == ERANGE) {
         *errnop = rc;
         return NSS_STATUS_TRYAGAIN;
+      } else {
+        *errnop = rc;
+        return NSS_STATUS_UNAVAIL;
       }
     } else if (uid < current_uid) {
       k = 2 * k + 1;
@@ -272,7 +275,7 @@ enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
   while (current_offset != 0 && current_offset < cache->header.text_offset) {
     if (current_offset + NAME_NODE_HEADER_SIZE > cache->map_size) {
       *errnop = EINVAL;
-      return NSS_STATUS_TRYAGAIN;
+      return NSS_STATUS_UNAVAIL;
     }
     uint64_t text_offset = read_le64(base + current_offset);
     uint64_t left_offset = read_le64(base + current_offset + 8);
@@ -281,7 +284,7 @@ enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
 
     if (current_offset + NAME_NODE_HEADER_SIZE + current_name_len > cache->map_size) {
       *errnop = EINVAL;
-      return NSS_STATUS_TRYAGAIN;
+      return NSS_STATUS_UNAVAIL;
     }
     const char* current_name = (const char*)(base + current_offset + NAME_NODE_HEADER_SIZE);
 
@@ -299,16 +302,19 @@ enum nss_status lookup_passwd_by_name_r(PasswdCache* cache, const char* name,
         struct line_info info;
         if (get_line_info(cache, text_offset, &info) != 0) {
           *errnop = EINVAL;
-          return NSS_STATUS_TRYAGAIN;
+          return NSS_STATUS_UNAVAIL;
         }
         int rc =
             parse_passwd_line_r(info.start, info.len, result, buffer, buflen);
         if (rc == 0) {
           *errnop = 0;
           return NSS_STATUS_SUCCESS;
-        } else {
+        } else if (rc == ERANGE) {
           *errnop = rc;
           return NSS_STATUS_TRYAGAIN;
+        } else {
+          *errnop = rc;
+          return NSS_STATUS_UNAVAIL;
         }
       }
       cmp = name_len < current_name_len ? -1 : 1;
@@ -367,7 +373,11 @@ enum nss_status passwd_cache_iter_next_r(PasswdCache* cache,
   int rc = parse_passwd_line_r(line_start, line_len, result, buffer, buflen);
   if (rc != 0) {
     *errnop = rc;
-    return NSS_STATUS_TRYAGAIN;
+    if (rc == ERANGE) {
+      return NSS_STATUS_TRYAGAIN;
+    } else {
+      return NSS_STATUS_UNAVAIL;
+    }
   }
 
   // Advance iterator to start of next line, or -1 if end of text.

--- a/test/oslogin_passwd_cache_reader_test.cc
+++ b/test/oslogin_passwd_cache_reader_test.cc
@@ -85,7 +85,7 @@ TEST(OsLoginPasswdCacheReaderTest, MalformedNameIndexOOBRead) {
 
   enum nss_status status = lookup_passwd_by_name_r(cache, "testuser", &pwd, buf, sizeof(buf), &errnop);
 
-  EXPECT_EQ(NSS_STATUS_TRYAGAIN, status);
+  EXPECT_EQ(NSS_STATUS_UNAVAIL, status);
   EXPECT_EQ(EINVAL, errnop);
 
   close_passwd_cache(cache);

--- a/test/oslogin_passwd_cache_reader_test.cc
+++ b/test/oslogin_passwd_cache_reader_test.cc
@@ -16,6 +16,10 @@
 
 #include <cerrno>
 #include <string>
+#include <fstream>
+#include <ios>
+#include <cstdio>
+#include <endian.h>
 
 #include <gtest/gtest.h>
 #include <nss.h>
@@ -43,6 +47,49 @@ TEST(OsLoginPasswdCacheReaderTest, MissingFile) {
             lookup_passwd_by_name_r(nullptr, "user1000", &pwd, buf, sizeof(buf),
                                     &errnop));
   EXPECT_EQ(ENOENT, errnop);
+}
+
+TEST(OsLoginPasswdCacheReaderTest, MalformedNameIndexOOBRead) {
+  std::string temp_dir = ::testing::TempDir();
+  std::string filename = temp_dir + "/malformed.cache";
+
+  std::ofstream out(filename, std::ios::binary);
+  ASSERT_TRUE(out.is_open());
+  uint64_t val64;
+  uint16_t val16;
+
+  // Header
+  val64 = htole64(48); out.write(reinterpret_cast<char*>(&val64), 8);
+  val64 = htole64(0);  out.write(reinterpret_cast<char*>(&val64), 8);
+  val64 = htole64(48); out.write(reinterpret_cast<char*>(&val64), 8);
+  val64 = htole64(1);  out.write(reinterpret_cast<char*>(&val64), 8);
+  val64 = htole64(80); out.write(reinterpret_cast<char*>(&val64), 8);
+  val64 = htole64(0);  out.write(reinterpret_cast<char*>(&val64), 8);
+
+  // Node at 48
+  val64 = htole64(80); out.write(reinterpret_cast<char*>(&val64), 8);
+  val64 = htole64(0);  out.write(reinterpret_cast<char*>(&val64), 8);
+  val64 = htole64(0);  out.write(reinterpret_cast<char*>(&val64), 8);
+  val16 = htole16(1000); out.write(reinterpret_cast<char*>(&val16), 2);
+
+  char pad[6] = {0};
+  out.write(pad, 6);
+  out.close();
+
+  PasswdCache* cache = open_passwd_cache(filename.c_str());
+  ASSERT_NE(cache, nullptr);
+
+  struct passwd pwd;
+  char buf[1024];
+  int errnop = 0;
+
+  enum nss_status status = lookup_passwd_by_name_r(cache, "testuser", &pwd, buf, sizeof(buf), &errnop);
+
+  EXPECT_EQ(NSS_STATUS_TRYAGAIN, status);
+  EXPECT_EQ(EINVAL, errnop);
+
+  close_passwd_cache(cache);
+  std::remove(filename.c_str());
 }
 
 }  // namespace


### PR DESCRIPTION
This PR contains two changes:

1. Some extra safety checks during user lookup, in case the cache file somehow got corrupted.
2. Adjustment of a few other preexisting safety checks, so that all nonretryable failures properly return `NSS_STATUS_UNAVAIL` instead of inappropriately returning `NSS_STATUS_TRYAGAIN`.